### PR TITLE
ZYZL-517 add strict mode based on gate rule config

### DIFF
--- a/zczh/base/db_orm/zh_db_config.cpp
+++ b/zczh/base/db_orm/zh_db_config.cpp
@@ -63,7 +63,7 @@ std::string sql_device_set::should_handle_income_plate(const std::string &_plate
                 {
                     ret = "";
                 }
-                else if (!vo->get_children<sql_order_history>("belong_order", "node_name == '%s'", node_name_enter.c_str()))
+                else if (!vo->get_children<sql_order_history>("belong_order", "node_name == '%s'", node_name_p_weight.c_str()))
                 {
                     ret = "";
                 }

--- a/zczh/base/db_orm/zh_db_config.h
+++ b/zczh/base/db_orm/zh_db_config.h
@@ -408,6 +408,7 @@ public:
     std::string oem_name;
     long weight_turn = 0;
     std::string issue_card_path;
+    long gate_strict = 0;
     virtual std::vector<sqlite_orm_column> self_columns_defined()
     {
         std::vector<sqlite_orm_column> ret;
@@ -420,6 +421,7 @@ public:
         ret.push_back(sqlite_orm_column("oem_name", sqlite_orm_column::STRING, &oem_name));
         ret.push_back(sqlite_orm_column("weight_turn", sqlite_orm_column::INTEGER, &weight_turn));
         ret.push_back(sqlite_orm_column("issue_card_path", sqlite_orm_column::STRING, &issue_card_path));
+        ret.push_back(sqlite_orm_column("gate_strict", sqlite_orm_column::INTEGER, &gate_strict));
 
         return ret;
     }

--- a/zczh/base/idl/idl.thrift
+++ b/zczh/base/idl/idl.thrift
@@ -138,6 +138,7 @@ struct running_rule {
     6:string oem_name,
     7:i64 weight_turn,
     8:string issue_card_path
+    9:bool gate_strict,
 }
 
 struct device_run_time{

--- a/zczh/service/cli/rule_cli.cpp
+++ b/zczh/service/cli/rule_cli.cpp
@@ -155,6 +155,30 @@ void set_issue_card_path(std::ostream &out, std::vector<std::string> _params)
         TRH_CLOSE();
     }
 }
+static void set_gate_strict(std::ostream &out, std::vector<std::string> _params)
+{
+    if (_params.size() != 0)
+    {
+        out << "参数错误" << std::endl;
+    }
+    else
+    {
+        THR_DEF_CIENT(config_management);
+        THR_CONNECT(config_management);
+        try
+        {
+            running_rule tmp;
+            client->get_rule(tmp);
+            tmp.gate_strict = true;
+            client->set_rule(tmp);
+        }
+        catch (const gen_exp &e)
+        {
+            out << e.msg << std::endl;
+        }
+        TRH_CLOSE();
+    }
+}
 static void clear(std::ostream &out, std::vector<std::string> _params)
 {
     if (_params.size() != 0)
@@ -189,6 +213,7 @@ std::unique_ptr<cli::Menu> make_rule_cli(const std::string &_menu_name)
     root_menu->Insert(CLI_MENU_ITEM(set_ticket_prefix), "设置磅单号前缀", {"前缀"});
     root_menu->Insert(CLI_MENU_ITEM(weight_turn_set), "设置称重轮数", {"轮数"});
     root_menu->Insert(CLI_MENU_ITEM(set_issue_card_path), "设置发卡系统路径", {"发卡系统中间数据库路径"});
+    root_menu->Insert(CLI_MENU_ITEM(set_gate_strict), "设置大门严格模式");
     root_menu->Insert(CLI_MENU_ITEM(clear), "清除配置");
 
     return root_menu;
@@ -228,6 +253,10 @@ std::string rule_cli::make_bdr()
     if (tmp.issue_card_path.length() > 0)
     {
         ret.push_back("set_issue_card_path " + tmp.issue_card_path);
+    }
+    if (tmp.gate_strict)
+    {
+        ret.push_back("set_gate_strict");
     }
 
     return util_join_string(ret, "\n");

--- a/zczh/service/lib/config_management_imp.cpp
+++ b/zczh/service/lib/config_management_imp.cpp
@@ -324,6 +324,7 @@ bool config_management_handler::set_rule(const running_rule &rule)
         er->oem_name = rule.oem_name;
         er->weight_turn = rule.weight_turn;
         er->issue_card_path = rule.issue_card_path;
+        er->gate_strict = rule.gate_strict;
         ret = er->update_record();
     }
     else
@@ -360,6 +361,7 @@ void config_management_handler::get_rule(running_rule &_return)
         _return.oem_name = er->oem_name;
         _return.weight_turn = er->weight_turn;
         _return.issue_card_path = er->issue_card_path;
+        _return.gate_strict = er->gate_strict;
     }
 }
 

--- a/zczh/service/lib/device_management_imp.h
+++ b/zczh/service/lib/device_management_imp.h
@@ -180,6 +180,8 @@ public:
     void sm_trigger(int64_t sm_id, std::function<bool(abs_state_machine &_sm)> update_func);
     void sm_run_in_scale(int64_t sm_id, std::function<void(abs_state_machine &_sm)> runner);
 
+    std::string gate_proc_id_plate(const std::string &_id,const std::string &_plate, bool _is_enter, sql_device_set &_set);
+
     static int64_t get_same_side_device(int64_t _input_id, const std::string &_type);
     static int64_t get_diff_side_device(int64_t _input_id, const std::string &_type);
 };


### PR DESCRIPTION
增加了命令行配置大门严格模式，在严格模式下，只能允许：
1. 有订单信息且没有一次称重的车辆通过大门
2. 有订单信息且确认装卸货的车辆通过大门