### PR TITLE
ZYZL-534-PC和手机首页的统计界面处新增各物料的装卸量总和

### DIFF
--- a/api/lib/plan_lib.js
+++ b/api/lib/plan_lib.js
@@ -208,6 +208,69 @@ module.exports = {
         });
         return { rows: rows, count: count };
     },
+    getPlansCount: async function (company, day_offset) {
+        let condition = {
+            plan_time: moment().add(day_offset, 'days').format('YYYY-MM-DD'),
+            stuffId: {
+                [db_opt.Op.in]: [],
+            },
+            is_buy: false
+        };
+        let countStuff = [];
+        let stuff = await company.getStuff({ where: { use_for_buy: false } }); 
+        let count = 0;
+        for (let i = 0; i < stuff.length; i++) {
+            const stuffItem = stuff[i];
+            const stuffName = stuffItem.name;
+            condition.stuffId[db_opt.Op.in].push(stuffItem.id);
+            let plans = await db_opt.get_sq().models.plan.findAll({
+                where: condition,
+            });
+            for (let j = 0; j < plans.length; j++) {
+                const plan = plans[j];
+                count += plan.count; 
+            }
+
+            countStuff.push({
+                name: stuffName,
+                count: count,
+            });
+        }
+        return countStuff;
+    },
+    getStatistic: async function (company, yesterday, today) {
+        let statistic = {};
+
+        if (yesterday) {
+            let yesterday_result = await this.getPlansCount(company, -1);
+            for (let i = 0; i < yesterday_result.length; i++) {
+                const item = yesterday_result[i];
+                if (!statistic[item.name]) {
+                    statistic[item.name] = { yesterday_count: 0, today_count: 0 };
+                }
+                statistic[item.name].yesterday_count = item.count;
+            }
+        }
+
+        if (today) {
+            let today_result = await this.getPlansCount(company, 0);
+            for (let i = 0; i < today_result.length; i++) {
+                const item = today_result[i];
+                if (!statistic[item.name]) {
+                    statistic[item.name] = { yesterday_count: 0, today_count: 0 };
+                }
+                statistic[item.name].today_count = item.count;
+            }
+        }
+
+        let resultArray = Object.keys(statistic).map(key => ({
+            name: key,
+            yesterday_count: statistic[key].yesterday_count,
+            today_count: statistic[key].today_count
+        }));
+
+        return resultArray;
+    },
     make_plan_where_condition: function (_condition, search_buy = false) {
         let sq = db_opt.get_sq();
         let where_condition = {

--- a/api/module/stuff_module.js
+++ b/api/module/stuff_module.js
@@ -130,8 +130,6 @@ module.exports = {
             is_write: true,
             is_get_api: false,
             params: {
-                    yesterday:{ type: Number, have_to: false, mean: '昨天', example: 1},
-                    today:{ type: Number, have_to: false, mean: '今天', example: 1, }
             },
             result: {
                 statistic: {
@@ -144,7 +142,7 @@ module.exports = {
             },
             func: async function (body, token) {
                 let company = await rbac_lib.get_company_by_token(token);
-                let results = await plan_lib.getStatistic(company, body.yesterday, body.today);
+                let results = await plan_lib.getStatistic(company);
                 return { statistic: results };
             }
         },

--- a/api/module/stuff_module.js
+++ b/api/module/stuff_module.js
@@ -1,7 +1,6 @@
 const plan_lib = require('../lib/plan_lib');
 const rbac_lib = require('../lib/rbac_lib');
 const db_opt = require('../db_opt');
-const moment = require('moment');
 const sq = db_opt.get_sq();
 async function change_stuff_single_switch(stuff_id, switch_name, switch_value, token) {
     let sq = db_opt.get_sq();

--- a/api/module/stuff_module.js
+++ b/api/module/stuff_module.js
@@ -1,6 +1,7 @@
 const plan_lib = require('../lib/plan_lib');
 const rbac_lib = require('../lib/rbac_lib');
 const db_opt = require('../db_opt');
+const moment = require('moment');
 const sq = db_opt.get_sq();
 async function change_stuff_single_switch(stuff_id, switch_name, switch_value, token) {
     let sq = db_opt.get_sq();
@@ -121,6 +122,30 @@ module.exports = {
                         }
                     ), total: await company.countStuff()
                 };
+            }
+        },
+        get_count_by_today_yesterday: {   
+            name: '获取今日、昨日物料统计',
+            description: '获取今日、昨日物料统计',
+            is_write: true,
+            is_get_api: false,
+            params: {
+                    yesterday:{ type: Number, have_to: false, mean: '昨天', example: 1},
+                    today:{ type: Number, have_to: false, mean: '今天', example: 1, }
+            },
+            result: {
+                statistic: {
+                    type: Array, mean: '物料统计', explain: {
+                        name: {type: String, mean: '物料名称',example:'大米'},
+                        yesterday_count: {type: Number, mean: '昨日物料装载总量',example: 12},
+                        today_count: {type: Number, mean: '昨日物料数量装载总量',example: 12},
+                    }
+                }
+            },
+            func: async function (body, token) {
+                let company = await rbac_lib.get_company_by_token(token);
+                let results = await plan_lib.getStatistic(company, body.yesterday, body.today);
+                return { statistic: results };
             }
         },
         del: {

--- a/mt_gui/src/pages/Home.vue
+++ b/mt_gui/src/pages/Home.vue
@@ -64,7 +64,7 @@
         </fui-card>
     </module-filter>
     <fui-white-space size="default"></fui-white-space>
-    <module-filter require_module="customer">
+    <module-filter :rm_array="['sale_management', 'buy_management']">
         <fui-card title="物料统计" full color="black" size="35">
             <list-show ref="ss_list" :fetch_function="get_stuff_total" height="40vh" v-model="stuff_total">
                 <fui-table :height="table_height"   :itemList="totalCountData" :header="stuff_count_header"></fui-table>
@@ -265,8 +265,6 @@ export default {
         get_stuff_total: async function (pageNo) {
             let res = await this.$send_req('/stuff/get_count_by_today_yesterday', {
                 pageNo: pageNo,
-                yesterday: this.day_offset - 1,
-                today: this.day_offset,
             });
             this.totalCountData = res.statistic
             return this.totalCountData

--- a/mt_gui/src/pages/Home.vue
+++ b/mt_gui/src/pages/Home.vue
@@ -64,7 +64,7 @@
         </fui-card>
     </module-filter>
     <fui-white-space size="default"></fui-white-space>
-    <module-filter :rm_array="['sale_management', 'buy_management']">
+    <module-filter require_module="stuff">
         <fui-card title="物料统计" full color="black" size="35">
             <list-show ref="ss_list" :fetch_function="get_stuff_total" height="40vh" v-model="stuff_total">
                 <fui-table :height="table_height"   :itemList="totalCountData" :header="stuff_count_header"></fui-table>

--- a/mt_gui/src/pages/Home.vue
+++ b/mt_gui/src/pages/Home.vue
@@ -64,6 +64,14 @@
         </fui-card>
     </module-filter>
     <fui-white-space size="default"></fui-white-space>
+    <module-filter require_module="customer">
+        <fui-card title="物料统计" full color="black" size="35">
+            <list-show ref="ss_list" :fetch_function="get_stuff_total" height="40vh" v-model="stuff_total">
+                <fui-table :height="table_height"   :itemList="totalCountData" :header="stuff_count_header"></fui-table>
+            </list-show>
+        </fui-card>
+    </module-filter>
+    <fui-white-space size="default"></fui-white-space>
     <module-filter require_module="stuff">
         <fui-card title="通知管理" full color="black" size="35">
             <fui-textarea flexStart isCounter label="下单通知" maxlength="2000" placeholder="请输入内容" v-model="notice.notice"></fui-textarea>
@@ -96,12 +104,26 @@ export default {
             },
             stuff2buy: [],
             stuff2sale: [],
+            stuff_total:[],
             charts: [],
             notice: {
                 notice: '',
                 driver_notice: '',
             },
             tableData: [],
+            stuff_count_header: [{
+                prop: 'name',
+                label: '物料',
+                width: '400',
+            }, {
+                prop: 'yesterday_count',
+                label: '昨日',
+                width: '200',
+            }, {
+                prop: 'today_count',
+                label: '今日',
+                width: '200',
+            }],
             headerData: [{
                 prop: 'company_name',
                 label: '客户',
@@ -239,6 +261,15 @@ export default {
             } else {
                 return []
             }
+        },
+        get_stuff_total: async function (pageNo) {
+            let res = await this.$send_req('/stuff/get_count_by_today_yesterday', {
+                pageNo: pageNo,
+                yesterday: this.day_offset - 1,
+                today: this.day_offset,
+            });
+            this.totalCountData = res.statistic
+            return this.totalCountData
         },
         get_stuff2sale: async function (pageNo) {
             if (this.$has_module('supplier')) {

--- a/mt_pc/src/views/dashboard.vue
+++ b/mt_pc/src/views/dashboard.vue
@@ -38,6 +38,26 @@
                 </div>
             </el-card>
 
+            <el-card class="box-card" :body-style="{padding : 0}" >
+                <div slot="header" class="clearfix">
+                    <span>物料统计</span>
+                </div>
+                <div class="grid-content bg-purple-dark">
+                    <page-content ref="count_statistic_page" body_key="statistic" :req_body="{today: 0, yesterday: -1}" :req_url="total_count_req_url" :enable="true" @data_loaded="stat_loading = false" >
+                        <template v-slot:default="slotProps">
+                            <el-table  ref="stuff_count_table" v-loading="stat_loading" fixed :data="slotProps.content" stripe style="width: 100%" >
+                                <el-table-column prop="name" label="物料名称">
+                                </el-table-column>
+                                <el-table-column prop="yesterday_count" label="昨天" min-width="25">
+                                </el-table-column>
+                                <el-table-column prop="today_count" label="今天" min-width="25">
+                                </el-table-column>
+                            </el-table>
+                        </template>
+                    </page-content>
+                </div>
+            </el-card>
+
             <el-card class="box-card" :body-style="{padding : 0}" v-if="module_filter('customer')">
                 <div slot="header" class="clearfix">
                     <span>采购提单</span>
@@ -145,10 +165,11 @@ export default {
             day_offset: "0",
             tableData: [],
             charts: [],
-            notice: {
+            notice: {   
                 notice: '',
                 driver_notice: '',
             },
+            total_count_req_url: '/stuff/get_count_by_today_yesterday',
             req_url: '/sale_management/get_count_by_customer',
             sb_url: '/customer/get_stuff_on_sale',
             ss_url: '/supplier/get_stuff_need_buy'

--- a/mt_pc/src/views/dashboard.vue
+++ b/mt_pc/src/views/dashboard.vue
@@ -38,12 +38,12 @@
                 </div>
             </el-card>
 
-            <el-card class="box-card" :body-style="{padding : 0}" >
+            <el-card class="box-card" :body-style="{padding : 0}" v-if="module_filter('sale_management') || module_filter('sale_management_order')">
                 <div slot="header" class="clearfix">
                     <span>物料统计</span>
                 </div>
                 <div class="grid-content bg-purple-dark">
-                    <page-content ref="count_statistic_page" body_key="statistic" :req_body="{today: 0, yesterday: -1}" :req_url="total_count_req_url" :enable="true" @data_loaded="stat_loading = false" >
+                    <page-content ref="count_statistic_page" body_key="statistic"  :req_url="total_count_req_url" :enable="true" @data_loaded="stat_loading = false" >
                         <template v-slot:default="slotProps">
                             <el-table  ref="stuff_count_table" v-loading="stat_loading" fixed :data="slotProps.content" stripe style="width: 100%" >
                                 <el-table-column prop="name" label="物料名称">

--- a/mt_pc/src/views/dashboard.vue
+++ b/mt_pc/src/views/dashboard.vue
@@ -6,7 +6,7 @@
             <el-row>
                 <el-col :span="12" v-for="(chartOption, index) in charts" :key="index">
                     <div class="grid-content bg-purple-dark">
-                        <ChartComponent :chartOption="chartOption" />      
+                        <ChartComponent :chartOption="chartOption" />
                     </div>
                 </el-col>
             </el-row>
@@ -38,7 +38,7 @@
                 </div>
             </el-card>
 
-            <el-card class="box-card" :body-style="{padding : 0}" v-if="module_filter('sale_management') || module_filter('buy_management')">
+            <el-card class="box-card" :body-style="{padding : 0}" v-if="module_filter('stuff')">
                 <div slot="header" class="clearfix">
                     <span>物料统计</span>
                 </div>
@@ -113,7 +113,7 @@
             </el-card>
         </el-col>
     </el-row>
-    <el-row :gutter="10"> 
+    <el-row :gutter="10">
         <el-col :span="12">
             <div class="grid-content bg-purple-dark" v-if="module_filter('stuff')">
                 <el-card class="box-card">
@@ -165,7 +165,7 @@ export default {
             day_offset: "0",
             tableData: [],
             charts: [],
-            notice: {   
+            notice: {
                 notice: '',
                 driver_notice: '',
             },

--- a/mt_pc/src/views/dashboard.vue
+++ b/mt_pc/src/views/dashboard.vue
@@ -38,7 +38,7 @@
                 </div>
             </el-card>
 
-            <el-card class="box-card" :body-style="{padding : 0}" v-if="module_filter('sale_management') || module_filter('sale_management_order')">
+            <el-card class="box-card" :body-style="{padding : 0}" v-if="module_filter('sale_management') || module_filter('buy_management')">
                 <div slot="header" class="clearfix">
                     <span>物料统计</span>
                 </div>


### PR DESCRIPTION
1.后端添加获取所有物料昨天和今天的装载量
2.pc添加显示数据的组件
3.小程序添加显示数据的组件
<img width="362" alt="image" src="https://github.com/user-attachments/assets/0d25ced1-8173-41fa-8250-d38be2547032" />
![image](https://github.com/user-attachments/assets/adefe647-b6ba-4bff-9fb5-5744a60999e8)
