### PR TITLE
ZYZL-543-显示各个物料的统计信息功能改为不分页显示

### DIFF
--- a/mt_pc/src/views/dashboard.vue
+++ b/mt_pc/src/views/dashboard.vue
@@ -43,18 +43,17 @@
                     <span>物料统计</span>
                 </div>
                 <div class="grid-content bg-purple-dark">
-                    <page-content ref="count_statistic_page" body_key="statistic"  :req_url="total_count_req_url" :enable="true" @data_loaded="stat_loading = false" >
-                        <template v-slot:default="slotProps">
-                            <el-table  ref="stuff_count_table" v-loading="stat_loading" fixed :data="slotProps.content" stripe style="width: 100%" >
-                                <el-table-column prop="name" label="物料名称">
-                                </el-table-column>
-                                <el-table-column prop="yesterday_count" label="昨天" min-width="25">
-                                </el-table-column>
-                                <el-table-column prop="today_count" label="今天" min-width="25">
-                                </el-table-column>
-                            </el-table>
-                        </template>
-                    </page-content>
+                <el-table 
+                    ref="stuff_count_table" 
+                    v-loading="stat_loading" 
+                    :data="tableData" 
+                    stripe 
+                    style="width: 100%"
+                >
+                    <el-table-column prop="name" label="物料名称"></el-table-column>
+                    <el-table-column prop="yesterday_count" label="昨天" min-width="25"></el-table-column>
+                    <el-table-column prop="today_count" label="今天" min-width="25"></el-table-column>
+                </el-table>
                 </div>
             </el-card>
 
@@ -169,7 +168,6 @@ export default {
                 notice: '',
                 driver_notice: '',
             },
-            total_count_req_url: '/stuff/get_count_by_today_yesterday',
             req_url: '/sale_management/get_count_by_customer',
             sb_url: '/customer/get_stuff_on_sale',
             ss_url: '/supplier/get_stuff_need_buy'
@@ -178,9 +176,15 @@ export default {
     mounted() {
         this.init_brief_info()
         this.init_statistic()
+        this.show_today_yesterday();
     },
 
     methods: {
+        show_today_yesterday: async function () {
+            this.stat_loading = true;
+            let resp = await this.$send_req('/stuff/get_count_by_today_yesterday', {});
+            this.tableData = resp.statistic;
+        },
         save_notice: async function () {
             await this.$send_req('/stuff/set_notice', this.notice);
             this.$message({


### PR DESCRIPTION
1.显示各个物料的统计信息功能改为不分页显示
2.修改了mt_pc/src/views/dashboard.vue文件
![image](https://github.com/user-attachments/assets/706fe621-5449-4ecf-8f6e-a4a1fa3574fc)
