### PR TITLE
ZYZL-536-基于物料增加配置项-自动确认装卸货

### DIFF
--- a/api/api_param_result_define.js
+++ b/api/api_param_result_define.js
@@ -278,6 +278,7 @@ module.exports = {
                     }
                 },
                 manual_weight: { type: Boolean, mean: '是否需要手动计量', example: false },
+                auto_confirm_goods: { type: Boolean, mean: '是否自动确认装卸货', example: false },
                 checkout_delay: { type: Boolean, mean: '是否需要延迟结算', example: false },
                 ticket_prefix: { type: String, mean: '磅单号前缀', example: 'LNG' },
                 need_expect_weight: { type: Boolean, mean: '是否需要预计重量', example: false },

--- a/api/db_opt.js
+++ b/api/db_opt.js
@@ -202,6 +202,7 @@ let db_opt = {
             second_unit: { type: DataTypes.STRING },
             coefficient: { type: DataTypes.DECIMAL(12, 2), defaultValue: 1.00 , get:getDecimalValue('coefficient')},
             add_base:{type: DataTypes.STRING},
+            auto_confirm_goods:{type: DataTypes.BOOLEAN, defaultValue: false}
         },
         contract: {
             id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },

--- a/api/module/scale_module.js
+++ b/api/module/scale_module.js
@@ -83,7 +83,16 @@ module.exports = {
                 result: { type: Boolean, mean: '结果', example: true }
             },
             func: async function (body, token) {
-                await plan_lib.plan_enter(body.plan_id, token, body.is_exit);
+                await plan_lib.action_in_plan(body.plan_id, token, -1, async (plan) => {
+                    let stuff = await plan.getStuff();
+                    if (stuff && stuff.auto_confirm_goods && !body.is_exit) {
+                        module.exports.methods.confirm_vehicle.func({
+                            is_confirm: true,
+                            plan_id: body.plan_id
+                        }, token);
+                    }
+                    await plan_lib.plan_enter(body.plan_id, token, body.is_exit);
+                });
                 return { result: true };
             },
         },

--- a/api/module/stuff_module.js
+++ b/api/module/stuff_module.js
@@ -91,6 +91,7 @@ module.exports = {
                         close_today: { type: Boolean, mean: '是否关闭今天的计划', example: false },
                         second_unit: { type: String, mean: '第二单位', example: '千克' },
                         coefficient: { type: Number, mean: '系数', example: 1.0 },
+                        auto_confirm_goods: { type: Boolean, mean: '是否自动确认货物', example: false },
                         add_base: { type: String, mean: '自增基础', example: 'day' },
                         sct_scale_items: {
                             type: Array, mean: '结构化计量项', explain: {
@@ -261,6 +262,22 @@ module.exports = {
             },
             func: async function (body, token) {
                 return await change_stuff_single_switch(body.stuff_id, 'need_expect_weight', body.need_expect_weight, token);
+            },
+        },
+        auto_confirm_goods: {
+            name: '配置货物是否自动确认装货',
+            description: '配置货物是否自动确认装货',
+            is_write: true,
+            is_get_api: false,
+            params: {
+                stuff_id: { type: Number, have_to: true, mean: '货物ID', example: 1 },
+                auto_confirm_goods: { type: Boolean, have_to: true, mean: '是否自动确认装货', example: true },
+            },
+            result: {
+                result: { type: Boolean, mean: '结果', example: true }
+            },
+            func: async function (body, token) {
+                return await change_stuff_single_switch(body.stuff_id, 'auto_confirm_goods', body.auto_confirm_goods, token);
             },
         },
         set_unit_coefficient:{

--- a/automation/stuff/plan_standard.robot
+++ b/automation/stuff/plan_standard.robot
@@ -404,9 +404,9 @@ Auto confirm Goods With Plan
     ${plan_id}  Get From Dictionary  ${plan}  id  id
     Confirm A Plan  ${plan}
     Manual Pay A Plan    ${plan}
-    Check And Set Is Confirm  ${plan}  ${False}
+    Check Plan Was Confirmed  ${plan_id}  ${False}
     Plan Enter  ${plan}
-    Check And Set Is Confirm  ${plan}  ${True}
+    Check Plan Was Confirmed  ${plan_id}  ${True}
 
 *** Keywords ***
 Verify Order Detail
@@ -467,14 +467,11 @@ Verify Order Detail
         END
         Should Be True  ${found_node}
     END
-Check And Set Is Confirm
-    [Arguments]  ${plan}  ${expected_value}
-    ${is_confirm}  Run Keyword And Return Status  Get From Dictionary  ${plan}  is_confirm
-    IF  ${is_confirm} == ${expected_value}
-        Log  is_confirm is ${expected_value}
-    ELSE
-        Set To Dictionary  ${plan}  is_confirm  ${expected_value}
-    END
+Check Plan Was Confirmed
+    [Arguments]  ${plan_id}  ${is_confirm}=${True}
+    ${focus_plan}  Get Plan By Id  ${plan_id}
+    ${check_confirm}  Get From Dictionary  ${focus_plan}  confirmed  ${False}
+    Should Be Equal  ${check_confirm}  ${is_confirm}
 Verify Plan Detail
     [Arguments]  ${plan}  ${mv}  ${bv}  ${dv}  ${price}  ${status}  ${stuff_name}  ${check_in_time}=${False}  ${enter_check}=${False}
     Should Be Equal As Strings  ${plan}[behind_vehicle][plate]  ${bv}[plate]

--- a/automation/stuff/plan_standard.robot
+++ b/automation/stuff/plan_standard.robot
@@ -394,6 +394,20 @@ Input And Check Stuff Unit Coefficient
     Should Be Equal As Numbers  ${p_resp}[coefficient]  ${1.5}
     Should Be Equal As Strings  ${p_resp}[second_unit]  千克
     
+Auto confirm Goods With Plan
+    [Teardown]  Plan Reset
+    Set Auto Confirm Goods
+    ${mv}  Search Main Vehicle by Index  0
+    ${bv}  Search behind Vehicle by Index  0
+    ${dv}  Search Driver by Index  0
+    ${plan}  Create A Plan  ${bv}[id]  ${mv}[id]  ${dv}[id]
+    ${plan_id}  Get From Dictionary  ${plan}  id  id
+    Confirm A Plan  ${plan}
+    Manual Pay A Plan    ${plan}
+    Check And Set Is Confirm  ${plan}  ${False}
+    Plan Enter  ${plan}
+    Check And Set Is Confirm  ${plan}  ${True}
+
 *** Keywords ***
 Verify Order Detail
     [Arguments]  ${plan}  ${mv}  ${bv}  ${dv}  ${price}  ${status}  ${stuff_name}  ${check_in_time}=${False}  ${enter_check}=${False}
@@ -452,6 +466,14 @@ Verify Order Detail
             END
         END
         Should Be True  ${found_node}
+    END
+Check And Set Is Confirm
+    [Arguments]  ${plan}  ${expected_value}
+    ${is_confirm}  Run Keyword And Return Status  Get From Dictionary  ${plan}  is_confirm
+    IF  ${is_confirm} == ${expected_value}
+        Log  is_confirm is ${expected_value}
+    ELSE
+        Set To Dictionary  ${plan}  is_confirm  ${expected_value}
     END
 Verify Plan Detail
     [Arguments]  ${plan}  ${mv}  ${bv}  ${dv}  ${price}  ${status}  ${stuff_name}  ${check_in_time}=${False}  ${enter_check}=${False}

--- a/automation/stuff/stuff_opt.resource
+++ b/automation/stuff/stuff_opt.resource
@@ -510,7 +510,10 @@ Set Stuff Manual Weight
     [Arguments]  ${stuff_id}=${test_stuff}[id]  ${token}=${sc_admin_token}  ${is_manual_weight}=${True}
     ${req}  Create Dictionary  stuff_id=${stuff_id}  manual_weight=${is_manual_weight}
     Req to Server    /stuff/manual_weight_config    ${token}    ${req}
-
+Set Auto Confirm Goods
+    [Arguments]  ${stuff_id}=${test_stuff}[id]  ${token}=${sc_admin_token}  ${auto_confirm_goods}=${True}
+    ${req}  Create Dictionary  stuff_id=${stuff_id}  auto_confirm_goods=${auto_confirm_goods}
+    Req to Server  /stuff/auto_confirm_goods  ${token}  ${req}
 Input Plan Sct Info
     [Arguments]  ${plan_id}  ${psi_id}  ${value}  ${token}=${sc_admin_token}
     ${req}  Create Dictionary  plan_id=${plan_id}  psi_id=${psi_id}  value=${value}

--- a/mt_gui/src/subPage1/Stuff.vue
+++ b/mt_gui/src/subPage1/Stuff.vue
@@ -117,6 +117,19 @@
                     </fui-col>
                 </fui-row>
                 <fui-white-space size="large"></fui-white-space>
+                <fui-row>
+                    <fui-col :span="12">
+                        <fui-label>
+                            <fui-list-cell>
+                                <view class="fui-list__cell">
+                                    <fui-text size="28" text="自动确认装卸货"></fui-text>
+                                    <fui-switch :scaleRatio="0.7" :checked="item.auto_confirm_goods" @change="change_auto_confirm_goods($event,item)"></fui-switch>
+                                </view>
+                            </fui-list-cell>
+                        </fui-label>
+                    </fui-col>
+                </fui-row>
+                <fui-white-space size="large"></fui-white-space>
                 <view>
                     <fui-row>
                         <fui-col :span="24">
@@ -444,6 +457,12 @@ export default {
             await this.$send_req('/stuff/manual_weight_config', {
                 stuff_id: item.id,
                 manual_weight: event.detail.value
+            });
+        },
+        change_auto_confirm_goods: async function (event, item) {
+            await this.$send_req('/stuff/auto_confirm_goods', {
+                stuff_id: item.id,
+                auto_confirm_goods: event.detail.value
             });
         },
         change_need_enter_weight: async function (event, item) {

--- a/mt_pc/src/views/stuff/StuffConfig.vue
+++ b/mt_pc/src/views/stuff/StuffConfig.vue
@@ -28,6 +28,7 @@
                                             <el-switch v-model="scope.row.checkout_delay" inline-prompt active-text="延迟结算" @change="change_checkout_delay($event, scope.row)"></el-switch>
                                             <el-switch v-model="scope.row.manual_weight" inline-prompt active-text="手动计量" @change="change_manual_weight($event, scope.row)"></el-switch>
                                             <el-switch v-model="scope.row.need_expect_weight" inline-prompt active-text="需要填写期望重量" @change="change_expect_weight($event,scope.row)"></el-switch>
+                                            <el-switch v-model="scope.row.auto_confirm_goods" inline-prompt active-text="自动确认装卸货" @change="change_auto_confirm_goods($event,scope.row)"></el-switch>
                                             <div class="unit-input-group">
                                                 <div class="input-item">
                                                     <span class="unit-label">第二单位配置:</span>
@@ -549,6 +550,12 @@ export default {
             await this.$send_req('/stuff/expect_weight_config', {
                 stuff_id: item.id,
                 need_expect_weight: event
+            });
+        },
+        change_auto_confirm_goods: async function (event, item) {
+            await this.$send_req('/stuff/auto_confirm_goods', {
+                stuff_id: item.id,
+                auto_confirm_goods: event
             });
         },
         change_manual_weight: async function (event, item) {


### PR DESCRIPTION
1. 增加物料配置项：添加db_opt.js auto_confirm_goods字段
2. 增加物料配置项：前端增加switch开关（pc\小程序）
3. 增加物料配置项：scale_module.js增加单向校验is_exit为false
4. 增加物料配置项：添加自动化测试脚本
![image](https://github.com/user-attachments/assets/a7299d01-4816-4f9e-b503-a86430090ed5)
![image](https://github.com/user-attachments/assets/1987a7f0-1875-4fe6-b3b2-a9bf2eb6a3ac)
![image](https://github.com/user-attachments/assets/8b16fe82-af2b-4560-a0b6-8dbbfe64b969)
