### PR TITLE
ZYZL-555-第二单位小数点配置要扩大化

### DIFF
--- a/api/lib/plan_lib.js
+++ b/api/lib/plan_lib.js
@@ -1490,6 +1490,7 @@ module.exports = {
                     return value.toFixed(decimalPlaces);
                 })(),
             });
+        }
         let columns = [{
             header: '下单公司',
             key: 'create_company',
@@ -1585,7 +1586,7 @@ module.exports = {
         let file_name = '/uploads/plans' + uuid.v4() + '.xlsx';
         await workbook.xlsx.writeFile('/database' + file_name);
         return file_name;
-    }},
+    },
     make_exe_rate_file: async function (body, token) {
         let plans = await this.filter_plan4manager(body, token, false);
         let workbook = new ExcelJS.Workbook();

--- a/api/lib/plan_lib.js
+++ b/api/lib/plan_lib.js
@@ -251,7 +251,7 @@ module.exports = {
             countStuff.push({
                 name: stuffName,
                 count: totalCount ? totalCount : 0,
-                second_unit: stuffItem.second_unit ? stuffItem.second_unit : '无',
+                second_unit: stuffItem.second_unit ? stuffItem.second_unit : '吨',
                 second_unit_decimal: stuffItem.second_unit_decimal ? stuffItem.second_unit_decimal : 0
             })
         }
@@ -262,8 +262,8 @@ module.exports = {
         let yesterday_result = await this.getPlansCount(company, -1);
         for (let i = 0; i < yesterday_result.length; i++) {
             const item = yesterday_result[i];
-            if (!statistic[item.name] && item.second_unit) {
-                statistic[item.name] = { yesterday_count: 0, today_count: 0, second_unit: '无', second_unit_decimal : 0 };
+            if (!statistic[item.name]) {
+                statistic[item.name] = { yesterday_count: 0, today_count: 0, second_unit: '吨', second_unit_decimal : 0 };
             }
             statistic[item.name].yesterday_count = item.count;
             statistic[item.name].second_unit = item.second_unit;
@@ -275,7 +275,7 @@ module.exports = {
         for (let i = 0; i < today_result.length; i++) {
             const item = today_result[i];
             if (!statistic[item.name] && item.second_unit) {
-                statistic[item.name] = { yesterday_count: 0, today_count: 0, second_unit: '无', second_unit_decimal : 0 };
+                statistic[item.name] = { yesterday_count: 0, today_count: 0, second_unit: '吨', second_unit_decimal : 0 };
             }
             statistic[item.name].today_count = item.count;
             statistic[item.name].second_unit = item.second_unit;
@@ -1452,8 +1452,13 @@ module.exports = {
     },
     make_file_by_plans: async function (plans) {
         let json = [];
+        let unifiedDecimalPlaces = 2;
         for (let index = 0; index < plans.length; index++) {
             const element = plans[index];
+            const dp = element.stuff?.second_unit_decimal ?? 2;
+            if (dp > unifiedDecimalPlaces) {
+                unifiedDecimalPlaces = dp;
+            }
             json.push({
                 create_company: this.place_hold(element.company, { name: '(司机选择)' }).name,
                 accept_company: element.stuff.company.name,
@@ -1486,8 +1491,7 @@ module.exports = {
                     if (!element.stuff.second_unit) {
                         return value.toFixed(2);
                     }
-                    const decimalPlaces = element.stuff.second_unit_decimal ?? 2;
-                    return value.toFixed(decimalPlaces);
+                    return value.toFixed(dp);
                 })(),
             });
         }
@@ -1582,6 +1586,7 @@ module.exports = {
         worksheet.getColumn('count').numFmt = '0.00';
         worksheet.getColumn('unit_price').numFmt = '0.00';
         worksheet.getColumn('total_price').numFmt = '0.00';
+        worksheet.getColumn('second_value').numFmt = `0.${'0'.repeat(unifiedDecimalPlaces)}`;
 
         let file_name = '/uploads/plans' + uuid.v4() + '.xlsx';
         await workbook.xlsx.writeFile('/database' + file_name);

--- a/api/lib/plan_lib.js
+++ b/api/lib/plan_lib.js
@@ -251,37 +251,44 @@ module.exports = {
             countStuff.push({
                 name: stuffName,
                 count: totalCount ? totalCount : 0,
+                second_unit: stuffItem.second_unit ? stuffItem.second_unit : '无',
+                second_unit_decimal: stuffItem.second_unit_decimal ? stuffItem.second_unit_decimal : 0
             })
         }
         return countStuff;
     },
     getStatistic: async function (company) {
         let statistic = {};
-
         let yesterday_result = await this.getPlansCount(company, -1);
         for (let i = 0; i < yesterday_result.length; i++) {
             const item = yesterday_result[i];
-            if (!statistic[item.name]) {
-                statistic[item.name] = { yesterday_count: 0, today_count: 0 };
+            if (!statistic[item.name] && item.second_unit) {
+                statistic[item.name] = { yesterday_count: 0, today_count: 0, second_unit: '无', second_unit_decimal : 0 };
             }
             statistic[item.name].yesterday_count = item.count;
+            statistic[item.name].second_unit = item.second_unit;
+            statistic[item.name].second_unit_decimal = item.second_unit_decimal;
+
         }
 
         let today_result = await this.getPlansCount(company, 0);
         for (let i = 0; i < today_result.length; i++) {
             const item = today_result[i];
-            if (!statistic[item.name]) {
-                statistic[item.name] = { yesterday_count: 0, today_count: 0 };
+            if (!statistic[item.name] && item.second_unit) {
+                statistic[item.name] = { yesterday_count: 0, today_count: 0, second_unit: '无', second_unit_decimal : 0 };
             }
             statistic[item.name].today_count = item.count;
+            statistic[item.name].second_unit = item.second_unit;
+            statistic[item.name].second_unit_decimal = item.second_unit_decimal;
         }
 
         let resultArray = Object.keys(statistic).map(key => ({
             name: key,
             yesterday_count: statistic[key].yesterday_count,
-            today_count: statistic[key].today_count
+            today_count: statistic[key].today_count,
+            second_unit: statistic[key].second_unit,
+            second_unit_decimal : statistic[key].second_unit_decimal
         }));
-
         return resultArray;
     },
     make_plan_where_condition: function (_condition, search_buy = false) {
@@ -1473,9 +1480,16 @@ module.exports = {
                 subsidy_total_price: this.place_hold(element.subsidy_price, 0) * this.place_hold(element.count, 0),
                 subsidy_discount: (this.place_hold(element.subsidy_price, element.unit_price) / element.unit_price * 10).toFixed(1),
                 second_unit: this.place_hold(element.stuff.second_unit, ''),
-                second_value: (element.stuff.second_unit ? this.place_hold(element.stuff.coefficient, 1) * element.count : 0),
+                second_value: (() => {
+                    const coefficient = this.place_hold(element.stuff.coefficient, 2);
+                    const value = coefficient * element.count;
+                    if (!element.stuff.second_unit) {
+                        return value.toFixed(2);
+                    }
+                    const decimalPlaces = element.stuff.second_unit_decimal ?? 2;
+                    return value.toFixed(decimalPlaces);
+                })(),
             });
-        }
         let columns = [{
             header: '下单公司',
             key: 'create_company',
@@ -1567,7 +1581,6 @@ module.exports = {
         worksheet.getColumn('count').numFmt = '0.00';
         worksheet.getColumn('unit_price').numFmt = '0.00';
         worksheet.getColumn('total_price').numFmt = '0.00';
-        worksheet.getColumn('second_value').numFmt = '0.00';
 
         let file_name = '/uploads/plans' + uuid.v4() + '.xlsx';
         await workbook.xlsx.writeFile('/database' + file_name);

--- a/api/lib/plan_lib.js
+++ b/api/lib/plan_lib.js
@@ -1585,7 +1585,7 @@ module.exports = {
         let file_name = '/uploads/plans' + uuid.v4() + '.xlsx';
         await workbook.xlsx.writeFile('/database' + file_name);
         return file_name;
-    },
+    }},
     make_exe_rate_file: async function (body, token) {
         let plans = await this.filter_plan4manager(body, token, false);
         let workbook = new ExcelJS.Workbook();

--- a/api/module/stuff_module.js
+++ b/api/module/stuff_module.js
@@ -142,6 +142,8 @@ module.exports = {
                         name: { type: String, mean: '物料名称', example: '大米' },
                         yesterday_count: { type: Number, mean: '昨日物料装载总量', example: 12 },
                         today_count: { type: Number, mean: '昨日物料数量装载总量', example: 12 },
+                        second_unit: { type: String, mean: '第二单位', example: '千克' },
+                        second_unit_decimal: { type: Number, mean: '第二单位小数位数', example: 2 },
                     }
                 }
             },

--- a/mt_gui/src/pages/Home.vue
+++ b/mt_gui/src/pages/Home.vue
@@ -270,11 +270,9 @@ export default {
                 this.totalCountData = res.statistic
                 this.totalCountData.forEach(item => {
                     if(item.second_unit == '无'){
-                        item.second_unit = item.second_unit;
                         item.yesterday_count = item.yesterday_count.toFixed(2)
                         item.today_count = item.today_count.toFixed(2)
                     }else{
-                        item.second_unit = item.second_unit;
                         item.yesterday_count = item.yesterday_count.toFixed(item.second_unit_decimal)
                         item.today_count = item.today_count.toFixed(item.second_unit_decimal)
                     }

--- a/mt_gui/src/pages/Home.vue
+++ b/mt_gui/src/pages/Home.vue
@@ -269,7 +269,7 @@ export default {
                 let res = await this.$send_req('/stuff/get_count_by_today_yesterday', {});
                 this.totalCountData = res.statistic
                 this.totalCountData.forEach(item => {
-                    if(item.second_unit == '无'){
+                    if(item.second_unit == '吨'){
                         item.yesterday_count = item.yesterday_count.toFixed(2)
                         item.today_count = item.today_count.toFixed(2)
                     }else{

--- a/mt_gui/src/pages/Home.vue
+++ b/mt_gui/src/pages/Home.vue
@@ -112,7 +112,7 @@ export default {
             stuff_count_header: [{
                 prop: 'name',
                 label: '物料',
-                width: '400',
+                width: '350',
             }, {
                 prop: 'yesterday_count',
                 label: '昨日',
@@ -120,6 +120,10 @@ export default {
             }, {
                 prop: 'today_count',
                 label: '今日',
+                width: '160',
+            },{
+                prop: 'second_unit',
+                label: '单位',
                 width: '160',
             }],
             headerData: [{
@@ -265,8 +269,15 @@ export default {
                 let res = await this.$send_req('/stuff/get_count_by_today_yesterday', {});
                 this.totalCountData = res.statistic
                 this.totalCountData.forEach(item => {
-                    item.yesterday_count = item.yesterday_count.toFixed(2)
-                    item.today_count = item.today_count.toFixed(2)
+                    if(item.second_unit == '无'){
+                        item.second_unit = item.second_unit;
+                        item.yesterday_count = item.yesterday_count.toFixed(2)
+                        item.today_count = item.today_count.toFixed(2)
+                    }else{
+                        item.second_unit = item.second_unit;
+                        item.yesterday_count = item.yesterday_count.toFixed(item.second_unit_decimal)
+                        item.today_count = item.today_count.toFixed(item.second_unit_decimal)
+                    }
                 });
             }
         },

--- a/mt_pc/src/views/dashboard.vue
+++ b/mt_pc/src/views/dashboard.vue
@@ -181,11 +181,9 @@ export default {
             this.tableData = resp.statistic;
             this.tableData.forEach(item => {
                 if(item.second_unit == '无'){
-                    item.second_unit = item.second_unit;
                     item.yesterday_count = item.yesterday_count.toFixed(2)
                     item.today_count = item.today_count.toFixed(2)
                 }else{
-                    item.second_unit = item.second_unit;
                     item.yesterday_count = item.yesterday_count.toFixed(item.second_unit_decimal)
                     item.today_count = item.today_count.toFixed(item.second_unit_decimal)
                 }

--- a/mt_pc/src/views/dashboard.vue
+++ b/mt_pc/src/views/dashboard.vue
@@ -47,6 +47,7 @@
                         <el-table-column prop="name" label="物料名称"></el-table-column>
                         <el-table-column prop="yesterday_count" label="昨天" min-width="25"></el-table-column>
                         <el-table-column prop="today_count" label="今天" min-width="25"></el-table-column>
+                        <el-table-column prop="second_unit" label="单位" min-width="25"></el-table-column>
                     </el-table>
                 </div>
             </el-card>
@@ -179,8 +180,15 @@ export default {
             let resp = await this.$send_req('/stuff/get_count_by_today_yesterday', {});
             this.tableData = resp.statistic;
             this.tableData.forEach(item => {
-                item.yesterday_count = item.yesterday_count.toFixed(2)
-                item.today_count = item.today_count.toFixed(2)
+                if(item.second_unit == '无'){
+                    item.second_unit = item.second_unit;
+                    item.yesterday_count = item.yesterday_count.toFixed(2)
+                    item.today_count = item.today_count.toFixed(2)
+                }else{
+                    item.second_unit = item.second_unit;
+                    item.yesterday_count = item.yesterday_count.toFixed(item.second_unit_decimal)
+                    item.today_count = item.today_count.toFixed(item.second_unit_decimal)
+                }
             });
         },
         save_notice: async function () {

--- a/mt_pc/src/views/dashboard.vue
+++ b/mt_pc/src/views/dashboard.vue
@@ -180,7 +180,7 @@ export default {
             let resp = await this.$send_req('/stuff/get_count_by_today_yesterday', {});
             this.tableData = resp.statistic;
             this.tableData.forEach(item => {
-                if(item.second_unit == '无'){
+                if(item.second_unit == '吨'){
                     item.yesterday_count = item.yesterday_count.toFixed(2)
                     item.today_count = item.today_count.toFixed(2)
                 }else{


### PR DESCRIPTION
1.首页基于物料的统计显示
2.计划导出表中的第二单位值栏位
![企业微信截图_5aebd6b5-d50c-4e85-a7e1-9296015d6188](https://github.com/user-attachments/assets/214219f2-8e3e-434d-8f14-dd9fd7d56806)
![企业微信截图_53683835-0fcb-4959-ab6c-0551804b0758](https://github.com/user-attachments/assets/abc3214a-d648-4343-b78c-d7ab569d6dc6)
![企业微信截图_8c983285-3c43-40ef-a879-f4d6a6d2314a](https://github.com/user-attachments/assets/e375227c-4276-4b0e-b241-bccc7f50d4b9)
![企业微信截图_7e7fe5e2-790e-42f8-8ac6-0f4aa726c24f](https://github.com/user-attachments/assets/54c06adb-19e3-4a04-9bf5-686bad58097b)
