### PR TITLE
ZYZL-559-充值历史列表中增加冲销按钮

### DIFF
--- a/mt_pc/src/components/ContractShowTable.vue
+++ b/mt_pc/src/components/ContractShowTable.vue
@@ -124,6 +124,17 @@
                     <el-table-column prop="comment" label="充值原因"></el-table-column>
                     <el-table-column prop="operator" label="充值人"></el-table-column>
                     <el-table-column prop="time" label="充值时间"></el-table-column>
+                    <el-table-column label="操作">
+                        <template slot-scope="scope">
+                        <div v-if="scope.row.reversed" class="reversed-tag">已冲销</div>
+                            <el-button 
+                                v-else
+                                type="warning" 
+                                size="small" 
+                                @click="reverseCharge(scope.row)"
+                            >冲销</el-button>
+                        </template>
+                    </el-table-column>
                 </el-table>
             </template>
         </page-content>
@@ -184,6 +195,20 @@ export default {
         is_motive: Boolean,
     },
     methods: {
+        reverseCharge: function (charge) { 
+        this.$confirm('确定冲销该充值吗?', '提示', {
+            confirmButtonText: '确定',
+            cancelButtonText: '取消',
+            type: 'warning'
+        }).then(async () => {
+            await this.$send_req('/cash/charge', {
+                contract_id: this.focus_contract.id,
+                cash_increased: -parseFloat(charge.cash_increased),
+                comment: `回退${charge.time}的充值: ${charge.comment}`
+            });
+            this.$refs.charge_history.refresh(1);
+        });
+        },      
         del_contract: function (contract) {
             this.$confirm('确定删除该合同吗?', '提示', {
                 confirmButtonText: '确定',
@@ -355,5 +380,8 @@ export default {
 </script>
 
 <style>
-
+.reversed-tag {
+  color: #999;
+  font-weight: bold;
+}
 </style>

--- a/mt_pc/src/components/ContractShowTable.vue
+++ b/mt_pc/src/components/ContractShowTable.vue
@@ -126,7 +126,7 @@
                     <el-table-column prop="time" label="充值时间"></el-table-column>
                     <el-table-column label="操作">
                         <template slot-scope="scope">
-                        <div v-if="scope.row.reversed" class="reversed-tag">已冲销</div>
+                        <div v-if="scope.row.reversed">已冲销</div>
                             <el-button 
                                 v-else
                                 type="warning" 
@@ -196,7 +196,7 @@ export default {
     },
     methods: {
         reverseCharge: function (charge) { 
-        this.$confirm('确定冲销该充值吗?', '提示', {
+            this.$confirm('确定冲销该充值吗?', '提示', {
             confirmButtonText: '确定',
             cancelButtonText: '取消',
             type: 'warning'
@@ -380,8 +380,5 @@ export default {
 </script>
 
 <style>
-.reversed-tag {
-  color: #999;
-  font-weight: bold;
-}
+
 </style>


### PR DESCRIPTION
1.前端调用充值接口充值与之前相反的金额
2.原因写回退xxx
![image](https://github.com/user-attachments/assets/da048e9a-6aa4-4687-b815-9190e8b7163d)
![image](https://github.com/user-attachments/assets/2ba78e4f-80fd-4140-b68d-6b27cdadc7c3)
