### PR TITLE
ZYZL-564-磅单添加卸车地点显示

### DIFF
--- a/api/api_param_result_define.js
+++ b/api/api_param_result_define.js
@@ -198,6 +198,7 @@ module.exports = {
                 content: { type: String, mean: '内容', example: '内容' },
             }
         },
+        drop_address: { type: String, mean: '卸货地址', example: '卸货地址' },
     },
     device_status_define: {
         name: { type: String, mean: '设备名称', example: '设备名称' },

--- a/api/db_opt.js
+++ b/api/db_opt.js
@@ -122,7 +122,8 @@ let db_opt = {
             verify_pay_by_cash:{ type: DataTypes.BOOLEAN, defaultValue: false },
             show_sc_in_field:{ type: DataTypes.BOOLEAN, defaultValue: false },
             buy_config_hard:{type: DataTypes.BOOLEAN, defaultValue: false },
-            push_messages_writable_roles:{type: DataTypes.BOOLEAN, defaultValue: false }
+            push_messages_writable_roles:{type: DataTypes.BOOLEAN, defaultValue: false },
+            ticket_hasOrhasnt_place: { type: DataTypes.BOOLEAN, defaultValue: false },
         },
         plan: {
             id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },

--- a/api/module/global_module.js
+++ b/api/module/global_module.js
@@ -51,6 +51,12 @@ async function get_ticket_func(body, token) {
             content: element.content,
         });
     });
+    let drop_address = '';
+    if (plan.company.ticket_hasOrhasnt_place){
+        drop_address = plan.drop_address
+    }else{
+        drop_address = null
+    }
 
     return {
         id: plan.id,
@@ -84,6 +90,7 @@ async function get_ticket_func(body, token) {
         plan_sct_infos:plan.plan_sct_infos,
         delegate_stamp_path: delegate_stamp_path,
         extra_infos: extra_infos,
+        drop_address: drop_address,
     }
 }
 async function checkif_plan_checkinable(plan, driver, lat, lon) {
@@ -2000,6 +2007,20 @@ module.exports = {
                 let company = await rbac_lib.get_company_by_token(token);
                 return { push_messages_writable_roles: company.push_messages_writable_roles };
             }
-        }
+        },
+        get_ticket_hasOrhasnt_place:{
+            name:'获取榜单是否显示装卸车地点',
+            description:'获取榜单是否显示装卸车地点',
+            is_write: false,
+            is_get_api: false,
+            params: {},
+            result: {
+                ticket_hasOrhasnt_place: { type: Boolean, mean: '是否显示装卸车地点', example: true }
+            },
+            func: async function (body, token) {
+                let company = await rbac_lib.get_company_by_token(token);
+                return { ticket_hasOrhasnt_place: company.ticket_hasOrhasnt_place };    
+            }
+        },
     },
 }

--- a/api/module/stuff_module.js
+++ b/api/module/stuff_module.js
@@ -1300,6 +1300,26 @@ module.exports = {
                 return { result: true };
             }
         },
+        set_ticket_hasOrhasnt_place:{
+            name: '榜单上是否显示装卸车地点',
+            description: '榜单上是否显示装卸车地点',
+            is_write: true,
+            is_get_api: false,
+            params: {
+                ticket_hasOrhasnt_place: { type: Boolean, have_to: true, mean: '榜单上是否显示装卸车地点', example: true }
+            },
+            result: {
+                result: { type: Boolean, mean: '结果', example: true }
+            },
+            func: async function (body, token) {
+                let company = await rbac_lib.get_company_by_token(token);
+                if (company) {
+                    company.ticket_hasOrhasnt_place = body.ticket_hasOrhasnt_place;
+                    await company.save();
+                }
+                return { result: true };
+            }
+        },
         set_delay_checkout_time: {
             name: '设置延迟结算定时时间',
             description: '设置延迟结算定时时间',

--- a/mt_gui/src/pages/Ticket.vue
+++ b/mt_gui/src/pages/Ticket.vue
@@ -170,6 +170,12 @@ export default {
                 value: ticket.trans_company_name,
             })
         }
+        if(ticket.drop_address) {
+            this.ticket_content.list.push({
+                label: '卸货地址',
+                value: ticket.drop_address,
+            });
+        }
         ticket.plan_sct_infos.forEach(item => {
             this.ticket_content.list.push({
                 label: item.sct_scale_item.name,

--- a/mt_pc/src/views/stuff/GlobalStrategy.vue
+++ b/mt_pc/src/views/stuff/GlobalStrategy.vue
@@ -31,6 +31,10 @@
                     <el-switch v-model="push_messages_writable_roles" active-text="是否只推送消息给可写角色" @change="set_push_messages_writable_roles">
                     </el-switch>
                 </vue-cell>
+                <vue-cell width="3of12">
+                    <el-switch v-model="ticket_hasOrhasnt_place" active-text="榜单上是否显示装卸车地点" @change="set_ticket_hasOrhasnt_place">
+                    </el-switch>
+                </vue-cell>
             </vue-grid>
             <h3>代理配置</h3>
             <page-content ref="all_delegates" body_key="delegates" enable req_url="/stuff/get_delegates">
@@ -179,6 +183,7 @@ export default {
         return {
             show_add_contract_diag: false,
             push_messages_writable_roles: false,
+            ticket_hasOrhasnt_place: false,
             contract_id_selected: 0,
             focus_delegate_id: 0,
             new_delegate: {
@@ -224,6 +229,7 @@ export default {
         this.get_buy_config_hard();
         this.get_show_sc_in_field();
         this.get_push_messages_writable_roles();
+        this.get_ticket_hasOrhasnt_place();
     },
     methods: {
         add_extra_info_config: async function () {
@@ -437,6 +443,15 @@ export default {
         set_push_messages_writable_roles: async function () {
             await this.$send_req('/stuff/set_push_messages_writable_roles', {
                 push_messages_writable_roles: this.push_messages_writable_roles
+            });
+        },
+        get_ticket_hasOrhasnt_place: async function () {
+            let ret = await this.$send_req('/global/get_ticket_hasOrhasnt_place', {});
+            this.ticket_hasOrhasnt_place = ret.ticket_hasOrhasnt_place;
+        },
+        set_ticket_hasOrhasnt_place: async function () {
+            await this.$send_req('/stuff/set_ticket_hasOrhasnt_place', {
+                ticket_hasOrhasnt_place: this.ticket_hasOrhasnt_place
             });
         },
     }


### PR DESCRIPTION
1.在全局配置增加一个开关：磅单上是否显示卸车地点
2.开关打开后，则在磅单上显示卸车地点
![企业微信截图_9277badc-4d69-4b0c-bcb7-11be6d21ad21](https://github.com/user-attachments/assets/9eab2962-8142-459b-bf02-c832143f7859)
<img width="496" alt="企业微信截图_c758dc65-07af-4603-ac98-a4a620e2bbc7" src="https://github.com/user-attachments/assets/1bd159c6-4fdc-41a7-b052-fd2bfd188a7e" />
