### PR TITLE
ZYZL-566-手机端的导出页面-增加订单明细导出的时分秒过滤

### DIFF
--- a/mt_gui/src/pages/Export.vue
+++ b/mt_gui/src/pages/Export.vue
@@ -10,15 +10,28 @@
         <fui-date-picker range :show="show_plan_date" type="3" :value="begin_date" :valueEnd="end_date" @change="choose_date" @cancel="show_plan_date = false"></fui-date-picker>
         <u-divider lineColor="blue"></u-divider>
         <module-filter :rm_array="['sale_management', 'buy_management', 'supplier', 'customer']">
-            <u-cell-group title="计划导出">
+            <u-cell-group title="订单明细导出">
                 <module-filter :rm_array="['sale_management', 'buy_management']">
+                    <view>
+                        <view class="time-display">
+                            <text class="time-text">{{ begin_hour }}:{{ begin_minute }}:{{ begin_second }}</text>
+                            <text class="divider">-</text>
+                            <text class="time-text">{{ end_hour }}:{{ end_minute }}:{{ end_second }}</text>
+                        </view>
+                        <view style="display: flex;justify-content: center; gap: 10px;">
+                            <fui-button btnSize="mini" type="warning" @click="show_start_time = true">开始时间</fui-button>
+                            <fui-button btnSize="mini" type="warning" @click="show_end_time = true">结束时间</fui-button>
+                        </view>
+                        <fui-date-picker type="7" :show="show_start_time" :hour="begin_hour" :minute="begin_minute" :second="begin_second" @change="handleBeginTimeChange" @cancel="show_start_time = false" />
+                        <fui-date-picker type="7" :show="show_end_time" :hour="end_hour" :minute="end_minute" :second="end_second" @change="handleEndTimeChange" @cancel="show_end_time = false" />
+                    </view>
                     <view style="display:flex; justify-content: start;">
                         <data-filter filter_name="公司" :get_func="get_customers" search_key="name" tag_color="success" v-model="company_filter"></data-filter>
                         <data-filter filter_name="物料" :get_func="get_stuff" search_key="name" tag_color="purple" v-model="stuff_filter"></data-filter>
                     </view>
                 </module-filter>
                 <module-filter v-for="(single_module, index) in all_module" :key="index" :require_module="single_module">
-                    <u-cell :title="'导出' + button_name[index] + '计划'" isLink @click="export_plan('/' + single_module)"></u-cell>
+                    <u-cell :title="button_name[index]" isLink @click="export_plan('/' + single_module)"></u-cell>
                 </module-filter>
             </u-cell-group>
         </module-filter>
@@ -106,6 +119,8 @@ export default {
                 name: '',
             },
             show_plan_date: false,
+            show_start_time: false,
+            show_end_time: false,
             begin_date: '',
             cur_page: 0,
             end_date: '',
@@ -118,7 +133,7 @@ export default {
                 'supplier',
             ],
             button_name: [
-                '被采购', '被销售', '采购', '销售'
+                '销售接单', '采购接单', '采购下单', '销售下单'
             ],
         };
     },
@@ -134,6 +149,18 @@ export default {
                     });
                 }
             });
+        },
+        handleBeginTimeChange(e) {
+            this.begin_hour = e.hour;
+            this.begin_minute = e.minute;
+            this.begin_second = e.second;
+            this.show_start_time = false;
+        },
+        handleEndTimeChange(e) {
+            this.end_hour = e.hour;
+            this.end_minute = e.minute;
+            this.end_second = e.second;
+            this.show_end_time = false;
         },
         get_export_record: async function (pageNo) {
             let res = await this.$send_req('/global/get_export_record', {
@@ -155,6 +182,8 @@ export default {
                 end_time: this.end_date,
                 stuff_id: this.stuff_filter.id,
                 company_id: this.company_filter.id,
+                m_start_time: this.begin_date + ' ' + this.begin_hour + ':' + this.begin_minute + ':' + this.begin_second,
+                m_end_time: this.end_date + ' ' + this.end_hour + ':' + this.end_minute + ':' + this.end_second,
             });
             this.cur_page = 1;
         },
@@ -272,12 +301,46 @@ export default {
         let five_days_before = new Date(today.getTime() - 5 * 24 * 60 * 60 * 1000);
         this.begin_date = utils.dateFormatter(five_days_before, 'y-m-d', 4, false);
         this.end_date = utils.dateFormatter(today, 'y-m-d', 4, false);
+
+        this.begin_hour = today.getHours().toString().padStart(2, '0');
+        this.begin_minute = today.getMinutes().toString().padStart(2, '0');
+        this.begin_second = today.getSeconds().toString().padStart(2, '0');
+
+        this.end_hour = today.getHours().toString().padStart(2, '0');
+        this.end_minute = today.getMinutes().toString().padStart(2, '0');
+        this.end_second = today.getSeconds().toString().padStart(2, '0');
     },
     onPullDownRefresh() {
         this.$refs.dr.refresh();
         uni.stopPullDownRefresh();
     },
+
 }
 </script>
 
-<style></style>
+<style>
+.time-display {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px 15px;
+    background-color: #f5f5f5;
+    border-radius: 8px;
+    margin: 10px 0;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.time-text {
+    font-size: 16px;
+    font-weight: bold;
+    color: #333;
+    min-width: 80px;
+    text-align: center;
+}
+
+.divider {
+    margin: 0 10px;
+    color: #999;
+    font-size: 14px;
+}
+</style>


### PR DESCRIPTION
1.添加时间过滤器，fui没有一个选择时间组件可以支持选择时间段的
因此写入俩个时间选择器
2.替换文字跟pc段一样
<img width="524" alt="image" src="https://github.com/user-attachments/assets/21ea6bc6-a504-4c3e-a1ed-c2960bc1d074" />
<img width="401" alt="image" src="https://github.com/user-attachments/assets/e2be8fff-56c9-4864-b891-21e1a06bcc15" />
<img width="689" alt="image" src="https://github.com/user-attachments/assets/33a2d2b1-d9ca-45d4-8eff-a4777a931617" />
