### PR TITLE
ZYZL-568-卸车地点增加细节输入

### DIFF
--- a/api/db_opt.js
+++ b/api/db_opt.js
@@ -124,6 +124,7 @@ let db_opt = {
             buy_config_hard:{type: DataTypes.BOOLEAN, defaultValue: false },
             push_messages_writable_roles:{type: DataTypes.BOOLEAN, defaultValue: false },
             ticket_hasOrhasnt_place: { type: DataTypes.BOOLEAN, defaultValue: false },
+            support_location_detail: { type: DataTypes.BOOLEAN, defaultValue: false },
         },
         plan: {
             id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },

--- a/api/module/global_module.js
+++ b/api/module/global_module.js
@@ -2022,5 +2022,19 @@ module.exports = {
                 return { ticket_hasOrhasnt_place: company.ticket_hasOrhasnt_place };    
             }
         },
+        get_support_location_detail: {
+            name: '获取卸车地点支持细节输入',
+            description: '获取卸车地点支持细节输入',
+            is_write: false,
+            is_get_api: false,
+            params: {},
+            result: {
+                support_location_detail: { type: Boolean, mean: '是否支持卸车地点细节输入', example: true }
+            },
+            func: async function (body, token) {
+                let company = await rbac_lib.get_company_by_token(token);
+                return { support_location_detail: company.unloading_location_detailed };
+            }
+        }
     },
 }

--- a/api/module/stuff_module.js
+++ b/api/module/stuff_module.js
@@ -1320,6 +1320,26 @@ module.exports = {
                 return { result: true };
             }
         },
+        set_support_location_detail:{
+            name: '设置卸货地点是否显示详细地址',
+            description: '设置卸货地点是否显示详细地址',
+            is_write: true,
+            is_get_api: false,
+            params: {
+                support_location_detail: { type: Boolean, have_to: true, mean: '卸货地点是否显示详细地址', example: true }
+            },
+            result: {
+                result: { type: Boolean, mean: '结果', example: true }  
+                },
+            func: async function (body, token) {
+                let company = await rbac_lib.get_company_by_token(token);
+                if (company) {
+                    company.support_location_detail = body.support_location_detail;
+                    await company.save();
+                }
+                return { result: true };
+            }
+        },
         set_delay_checkout_time: {
             name: '设置延迟结算定时时间',
             description: '设置延迟结算定时时间',

--- a/mt_gui/src/subPage1/OrderCreate.vue
+++ b/mt_gui/src/subPage1/OrderCreate.vue
@@ -18,6 +18,9 @@
                     <fui-input placeholder="请输入卸车地点" disabled v-model="plan.drop_address"></fui-input>
                 </fui-form-item>
             </pick-regions>
+            <fui-form-item v-if="support_location_detail" label="详细地址" :padding="[0,'18px']" prop="location_detail">
+                <fui-input placeholder="请输入详细地址" v-model="plan.location_detail"></fui-input>
+            </fui-form-item>
         </view>
         <view v-else>
             <fui-form-item label="单价" :padding="[0,'18px']" prop="price">
@@ -153,6 +156,7 @@ export default {
             }],
             all_vt_list: [],
             show_add_vt: false,
+            support_location_detail: false,
             notice_show: false,
             show_behind_vehicle_plate: false,
             show_driver_info: false,
@@ -205,6 +209,7 @@ export default {
             plan: {
                 comment: "",
                 drop_address: "",
+                location_detail: "",
                 plan_time: "",
                 stuff_id: 0,
                 use_for: "",
@@ -265,6 +270,10 @@ export default {
                 pageNo: pageNo
             });
             return res.vehicle_teams;
+        },
+        get_support_location_detail: async function () {
+            let ret = await this.$send_req('/global/get_support_location_detail', {});
+            this.support_location_detail = ret.support_location_detail;
         },
         prepare_proxy_buy: function () {
             this.is_proxy = true;
@@ -593,11 +602,12 @@ export default {
                 let ele = this.vehicles[index];
                 let req = {
                     ...this.plan,
+                    drop_address: this.plan.drop_address + (this.plan.location_detail ? '-' + this.plan.location_detail : ''),
                     main_vehicle_id: ele.main_vehicle.id,
                     behind_vehicle_id: ele.behind_vehicle.id,
                     driver_id: ele.driver.id,
                     is_proxy: this.is_proxy,
-                    bidding_id: this.bidding_id,
+                    bidding_id: this.bidding_id,    
                     comment: ele.comment,
                 };
                 if (req.is_proxy) {
@@ -640,6 +650,7 @@ export default {
         if (this.notice) {
             this.notice_show = true;
         }
+        this.get_support_location_detail();
     },
 }
 </script>

--- a/mt_pc/src/views/order/OrderCreate.vue
+++ b/mt_pc/src/views/order/OrderCreate.vue
@@ -30,6 +30,9 @@
                     <el-form-item label="卸车地点" prop="drop_address">
                         <el-cascader v-model="plan.drop_address" placeholder="请选择，可搜索" :options="getRegion()" filterable></el-cascader>
                     </el-form-item>
+                    <el-form-item label="详细地址" prop="location_detail" v-if="support_location_detail">
+                        <el-input v-model="plan.location_detail" placeholder="请输入详细地址：门牌号" :options="getRegion()" filterable></el-input>
+                    </el-form-item>
                 </div>
                 <div v-else>
                     <el-form-item label="单价" prop="price">
@@ -169,7 +172,7 @@ export default {
 
             add_type: '',
             query: {},
-
+            support_location_detail: false,
             order_rules: {
                 plan_time: [{
                     required: true,
@@ -268,6 +271,7 @@ export default {
             plan: {
                 comment: "",
                 drop_address: [],
+                location_detail: "",
                 plan_time: "",
                 stuff_id: 0,
                 use_for: "",
@@ -318,6 +322,7 @@ export default {
         if (this.notice) {
             this.notice_show = true;
         }
+        this.get_support_location_detail();
     },
     methods: {
         onProxyChange(is_proxy) {
@@ -326,6 +331,10 @@ export default {
             this.plan.trans_company_name = this.saler_name;
             this.saler_name = tmp;
 
+        },
+        get_support_location_detail: async function () {
+            let ret = await this.$send_req('/global/get_support_location_detail', {});
+            this.support_location_detail = ret.support_location_detail;
         },
         deleteRow(index, rows) {
             rows.splice(index, 1);
@@ -451,7 +460,10 @@ export default {
                 for (let ele of this.vehicles) {
                     let req = {
                         ...this.plan,
-                        drop_address: this.plan.drop_address.join('-'),
+                        drop_address: [
+                            ...this.plan.drop_address,
+                            ...(this.plan.location_detail ? [this.plan.location_detail] : [])
+                        ].join('-'),
                         main_vehicle_id: ele.main_vehicle.id,
                         behind_vehicle_id: ele.behind_vehicle.id,
                         driver_id: ele.driver.id,

--- a/mt_pc/src/views/stuff/GlobalStrategy.vue
+++ b/mt_pc/src/views/stuff/GlobalStrategy.vue
@@ -35,6 +35,10 @@
                     <el-switch v-model="ticket_hasOrhasnt_place" active-text="榜单上是否显示装卸车地点" @change="set_ticket_hasOrhasnt_place">
                     </el-switch>
                 </vue-cell>
+                <vue-cell width="3of12">
+                    <el-switch v-model="support_location_detail" active-text="卸车地点支持细节输入" @change="set_support_location_detail">
+                    </el-switch>
+                </vue-cell>
             </vue-grid>
             <h3>代理配置</h3>
             <page-content ref="all_delegates" body_key="delegates" enable req_url="/stuff/get_delegates">
@@ -184,6 +188,7 @@ export default {
             show_add_contract_diag: false,
             push_messages_writable_roles: false,
             ticket_hasOrhasnt_place: false,
+            support_location_detail: false,
             contract_id_selected: 0,
             focus_delegate_id: 0,
             new_delegate: {
@@ -230,6 +235,7 @@ export default {
         this.get_show_sc_in_field();
         this.get_push_messages_writable_roles();
         this.get_ticket_hasOrhasnt_place();
+        this.get_support_location_detail();
     },
     methods: {
         add_extra_info_config: async function () {
@@ -454,6 +460,15 @@ export default {
                 ticket_hasOrhasnt_place: this.ticket_hasOrhasnt_place
             });
         },
+        set_support_location_detail: async function () {
+            await this.$send_req('/stuff/set_support_location_detail', {
+                support_location_detail: this.support_location_detail
+            });
+        },
+        get_support_location_detail: async function () {
+            let ret = await this.$send_req('/global/get_support_location_detail', {});
+            this.support_location_detail = ret.support_location_detail;
+        }
     }
 }
 </script>


### PR DESCRIPTION
1.增加全局开关：卸车地点支持细节输入
2.以上开关打开时,在手机端和PC端的创建订单页面中卸车地点的输入框中增加《详细地址》输入栏位
3.上述栏位的内容和原来的省市内容连在一起传给后端
![image](https://github.com/user-attachments/assets/41b3bf3c-1540-4de6-82a7-8907fb400483)
![image](https://github.com/user-attachments/assets/7dffa50f-36b8-40a7-b5de-e72c228f2e3f)
![image](https://github.com/user-attachments/assets/c1a31991-11ea-4c9f-bebc-91875fb42b37)
![image](https://github.com/user-attachments/assets/c90c9a0c-f5ee-4d3a-bb45-03648abad0a7)
