### PR TITLE
ZYZL-571-导出磅单时创建文件失败

### DIFF
--- a/api/module/global_module.js
+++ b/api/module/global_module.js
@@ -1264,7 +1264,8 @@ module.exports = {
                     const filePaths = [];
                     for (let index = 0; index < plans.length; index++) {
                         const plan = plans[index];
-                        let real_file_name = `${plan.id}-${plan.main_vehicle.plate}-${plan.behind_vehicle.plate}`;
+                        const uuid = require('uuid');
+                        let real_file_name = uuid.v4();
                         const filePath = '/uploads/ticket_' + real_file_name + '.png';
                         await do_web_cap(process.env.REMOTE_MOBILE_HOST + '/pages/Ticket?id=' + plan.id, '/database' + filePath);
                         filePaths.push(`/database${filePath}`);


### PR DESCRIPTION
1.把文件名设定为全局唯一名称
<img width="560" height="67" alt="image" src="https://github.com/user-attachments/assets/9e542c00-6ebb-423e-b8bb-fae51136d0cf" />
