### PR TITLE
ZYZL-576-磅单导出文件恢复可读编号

### DIFF
--- a/api/module/global_module.js
+++ b/api/module/global_module.js
@@ -1218,7 +1218,8 @@ module.exports = {
             },
             func: async function (body, token) {
                 let id = body.id;
-                let real_file_name = `${plan.id}-${plan.main_vehicle.plate}-${plan.behind_vehicle.plate}`;
+                const uuid = require('uuid');
+                real_file_name = uuid.v4();
                 const filePath = '/uploads/ticket_' + real_file_name + '.png';
                 await do_web_cap(process.env.REMOTE_MOBILE_HOST + '/pages/Ticket?id=' + id, '/database' + filePath);
                 return { url: filePath };
@@ -1250,19 +1251,9 @@ module.exports = {
                         if (plans.length === 0) throw { err_msg: '未找到磅单信息' };
 
                         const firstPlan = plans[0];
-                        if (!firstPlan.stuff?.company?.name) {
-                            throw { err_msg: '公司名称为空' };
-                        }
-                        if (!firstPlan.main_vehicle?.plate) {
-                            throw { err_msg: '主车号为空' };
-                        }
-                        if (!firstPlan.behind_vehicle?.plate) {
-                            throw { err_msg: '挂车号为空' };
-                        }
-
-                        const companyName = firstPlan.stuff.company.name.replace(/[\\/:*?"<>|]/g, '_');
-                        const mainPlate = firstPlan.main_vehicle.plate;
-                        const behindPlate = firstPlan.behind_vehicle.plate;
+                        const companyName = firstPlan.stuff?.company?.name ? firstPlan.stuff.company.name.replace(/[\\/:*?"<>|]/g, '_') : '未知公司';
+                        const mainPlate = firstPlan.main_vehicle?.plate || '无主车';
+                        const behindPlate = firstPlan.behind_vehicle?.plate || '无挂车';
                         const planId = firstPlan.id;
 
                         const zipName = `磅单导出_${companyName}_${mainPlate}-${behindPlate}_${planId}.zip`;
@@ -1287,7 +1278,6 @@ module.exports = {
                         }));
 
                         await archive.finalize();
-                        success = true;
                         console.log('Zip file created successfully', zipName);
                         return zipName;
                     } catch (error) {

--- a/api/module/global_module.js
+++ b/api/module/global_module.js
@@ -1220,7 +1220,7 @@ module.exports = {
                 let id = body.id;
                 let real_file_name = `${plan.id}-${plan.main_vehicle.plate}-${plan.behind_vehicle.plate}`;
                 const filePath = '/uploads/ticket_' + real_file_name + '.png';
-                await do_web_cap('https://console.d8sis.cn' + '/pages/Ticket?id=' + id, '/database' + filePath);
+                await do_web_cap(process.env.REMOTE_MOBILE_HOST + '/pages/Ticket?id=' + id, '/database' + filePath);
                 return { url: filePath };
             },
         },
@@ -1272,10 +1272,7 @@ module.exports = {
                             console.log(`正在生成 ${plan.id}`);
                             const fileName = module.exports.methods.generateTicketFilename(plan);
                             const filePath = path.join(tempDir, fileName);
-                            await do_web_cap(
-                                `https://console.d8sis.cn/pages/Ticket?id=${plan.id}`,
-                                filePath
-                            );
+                            await do_web_cap(process.env.REMOTE_MOBILE_HOST + '/pages/Ticket?id=' + id, '/database' + filePath);
                             console.log(`已生成 ${filePath}`);
                             return filePath;
                         }));


### PR DESCRIPTION
磅单导出文件名恢复为原来的车号公司组合命名
基于每次导出接口调用创建uuid命名的临时目录
把磅单文件先放到临时目录中再基于临时目录打包，导出执行完（无论成功失败）后把临时目录删掉