### PR TITLE
ZYZL-577-手机和PC端的订单列表页面增加单价和总价显示

### DIFF
--- a/api/db_opt.js
+++ b/api/db_opt.js
@@ -127,6 +127,7 @@ let db_opt = {
             access_control_permission: { type: DataTypes.BOOLEAN, defaultValue: false },
             support_location_detail: { type: DataTypes.BOOLEAN, defaultValue: false },
             barriergate_control_permission: { type: DataTypes.BOOLEAN, defaultValue: false },
+            is_the_order_display_price: { type: DataTypes.BOOLEAN, defaultValue: false },
             is_allowed_order_return: { type: DataTypes.BOOLEAN, defaultValue: false },
         },
         plan: {

--- a/api/db_opt.js
+++ b/api/db_opt.js
@@ -127,6 +127,7 @@ let db_opt = {
             access_control_permission: { type: DataTypes.BOOLEAN, defaultValue: false },
             support_location_detail: { type: DataTypes.BOOLEAN, defaultValue: false },
             barriergate_control_permission: { type: DataTypes.BOOLEAN, defaultValue: false },
+            is_allowed_order_return: { type: DataTypes.BOOLEAN, defaultValue: false },
         },
         plan: {
             id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },

--- a/api/module/global_module.js
+++ b/api/module/global_module.js
@@ -126,7 +126,7 @@ async function checkif_plan_checkinable(plan, driver, lat, lon) {
 }
 module.exports = {
     name: 'global',
-    description: '全局',
+    description: '全局',    
     methods: {
         driver_phone_online: {
             name: '司机手机号上线',
@@ -2018,6 +2018,20 @@ module.exports = {
             func: async function (body, token) {
                 let company = await rbac_lib.get_company_by_token(token);
                 return { barriergate_control_permission: company.barriergate_control_permission };
+            }
+        },
+        get_is_allowed_order_return: {
+            name: '获取是否允许订单回退',
+            description: '获取是否允许订单回退',
+            is_write: false,
+            is_get_api: false,
+            params: {},
+            result: {
+                is_allowed_order_return: { type: Boolean, mean: '是否允许订单回退', example: true }
+            },
+            func: async function (body, token) {
+                let company = await rbac_lib.get_company_by_token(token);
+                return { is_allowed_order_return: company.is_allowed_order_return };
             }
         },
         get_support_location_detail: {

--- a/api/module/global_module.js
+++ b/api/module/global_module.js
@@ -2053,6 +2053,20 @@ module.exports = {
                 return { support_location_detail: company.support_location_detail };
             }
         },
+        get_the_order_display_price: {
+            name: '获取订单列表是否显示价格',
+            description: '获取订单列表是否显示价格',
+            is_write: false,
+            is_get_api: false,
+            params: {},
+            result: {
+                is_the_order_display_price: { type: Boolean, mean: '是否显示价格', example: true }
+            },
+            func: async function (body, token) {
+                let company = await rbac_lib.get_company_by_token(token);
+                return { is_the_order_display_price: company.is_the_order_display_price };
+            }
+        },
         getPlansByTicketType: async function(body, token) {
             switch (body.ticket_type) {
                 case 'sale_management':

--- a/api/module/stuff_module.js
+++ b/api/module/stuff_module.js
@@ -1380,7 +1380,27 @@ module.exports = {
                 return { result: true };
             }
         },
-        set_delay_checkout_time: {
+        set_is_allowed_order_return: {
+            name: '设置是否允许订单回退',
+            description: '设置是否允许订单回退',
+            is_write: true,
+            is_get_api: false,
+            params: {
+                is_allowed_order_return: { type: Boolean, have_to: true, mean: '是否允许订单回退', example: true }
+            },
+            result: {
+                result: { type: Boolean, mean: '结果', example: true }
+            },
+            func: async function (body, token) {
+                let company = await rbac_lib.get_company_by_token(token);
+                if (company) {
+                    company.is_allowed_order_return = body.is_allowed_order_return;
+                    await company.save();
+                }
+                return { result: true };
+            }
+        },
+        set_delay_checkout_time: {  
             name: '设置延迟结算定时时间',
             description: '设置延迟结算定时时间',
             is_write: true,

--- a/api/module/stuff_module.js
+++ b/api/module/stuff_module.js
@@ -1380,6 +1380,26 @@ module.exports = {
                 return { result: true };
             }
         },
+        set_the_order_display_price: {
+            name: '设置订单列表是否显示价格',
+            description: '设置订单列表是否显示价格',
+            is_write: true,
+            is_get_api: false,
+            params: {
+                is_the_order_display_price: { type: Boolean, have_to: true, mean: '是否显示价格', example: true }
+            },
+            result: {
+                result: { type: Boolean, mean: '结果', example: true }
+            },
+            func: async function (body, token) {
+                let company = await rbac_lib.get_company_by_token(token);
+                if (company) {
+                    company.is_the_order_display_price = body.is_the_order_display_price;
+                    await company.save();
+                }
+                return { result: true };
+            }
+        },
         set_is_allowed_order_return: {
             name: '设置是否允许订单回退',
             description: '设置是否允许订单回退',

--- a/mt_gui/src/pages/OrderList.vue
+++ b/mt_gui/src/pages/OrderList.vue
@@ -56,7 +56,7 @@
     <u-checkbox-group v-model="plan_selected" placement="column">
         <list-show v-model="sp_data2show" ref="sold_plans" :fetch_function="get_sold_plans" height="70vh" search_key="search_cond" :fetch_params="[plan_filter, cur_get_url, cur_is_motion]">
             <view v-for="item in sp_data2show" :key="item.id">
-                <u-cell :title="item.company_show + '-' + item.stuff.name" clickable @click="prepare_plan_detail(item)">
+                <u-cell :title="item.company_show + '-' + item.stuff.name + (is_the_order_display_price && item.unit_price ? '-' + '( 单价:' + item.unit_price + (item.count != 0 ? ',总价:' + (item.unit_price * item.count).toFixed(2) : '') + ')' : '')" clickable @click="prepare_plan_detail(item)">
                     <view slot="icon" style="display:flex;">
                         <u-checkbox :name="item.id" shape="circle" v-if="select_active" size="25">
                         </u-checkbox>
@@ -616,6 +616,7 @@ export default {
             tabs: [],
             show_batch_copy: false,
             gallery_index: 0,
+            is_the_order_display_price: false,
             is_allowed_order_return: false,
         }
     },
@@ -1447,6 +1448,15 @@ export default {
         measurement_refresh: function () {
             this.refresh_plans();
             this.show_plan_detail = false;
+        },
+        get_price_display_config: async function () {
+            try {
+                const result = await this.$send_req('/global/get_the_order_display_price', {});
+                this.is_the_order_display_price = result.is_the_order_display_price;
+            } catch (error) {
+                console.error('获取价格显示配置失败:', error);
+                this.is_the_order_display_price = false;
+            }
         }
     },
     onPullDownRefresh() {
@@ -1460,6 +1470,7 @@ export default {
         tom.setDate(tom.getDate() + 1);
         this.default_time = utils.dateFormatter(tom, 'y-m-d', 4, false);
         this.init_number_of_sold_plan();
+        this.get_price_display_config();
         this.get_is_allowed_order_return();
     },
 }

--- a/mt_gui/src/pages/OrderList.vue
+++ b/mt_gui/src/pages/OrderList.vue
@@ -171,7 +171,7 @@
                             <fui-button v-if="focus_plan.status != 3 && plan_owner" btnSize="mini" text="取消" type="danger" @click="prepare_xxx_confirm(cur_cancel_url, '取消')"></fui-button>
                             <module-filter :rm_array="['sale_management', 'buy_management']" style="display:flex;">
                                 <fui-button v-if="focus_plan.status == 0" btnSize="mini" type="success" text="确认" @click="prepare_xxx_confirm(cur_confirm_url, '确认')"></fui-button>
-                                <fui-button v-if="focus_plan.status != 0" btnSize="mini" type="warning" text="回退" @click="show_rollback_confirm = true;"></fui-button>
+                                <fui-button v-if="focus_plan.status != 0 && is_allowed_order_return" btnSize="mini" type="warning" text="回退" @click="show_rollback_confirm = true;"></fui-button>
                                 <fui-button v-if="focus_plan.status != 3" btnSize="mini" type="danger" text="关闭" @click="prepare_xxx_confirm(cur_close_url, '关闭')"></fui-button>
                                 <fui-button v-if="(focus_plan.status == 1 && !focus_plan.is_buy)" btnSize="mini" type="success" text="验款" @click="prepare_pay_confirm('验款')"></fui-button>
                             </module-filter>
@@ -615,7 +615,8 @@ export default {
             deliver_time_type: '',
             tabs: [],
             show_batch_copy: false,
-            gallery_index: 0
+            gallery_index: 0,
+            is_allowed_order_return: false,
         }
     },
     computed: {
@@ -882,6 +883,10 @@ export default {
                 this.refresh_plans();
             }
             this.show_batch_copy = false;
+        },
+        get_is_allowed_order_return: async function () {
+            let ret = await this.$send_req('/global/get_is_allowed_order_return', {});
+            this.is_allowed_order_return = ret.is_allowed_order_return;
         },
         pick_address: function (e) {
             this.dup_plan.drop_address = e.map(item => item.name).join('-')
@@ -1455,6 +1460,7 @@ export default {
         tom.setDate(tom.getDate() + 1);
         this.default_time = utils.dateFormatter(tom, 'y-m-d', 4, false);
         this.init_number_of_sold_plan();
+        this.get_is_allowed_order_return();
     },
 }
 </script>

--- a/mt_pc/src/components/OrderDetail.vue
+++ b/mt_pc/src/components/OrderDetail.vue
@@ -1,4 +1,4 @@
-<template>
+                <template>
 <div>
     <vue-grid align="stretch" justify="around">
         <vue-cell width="12of12">
@@ -46,7 +46,7 @@
                         <span v-if="has_plan_reciever_permission">
                             <el-button v-if="plan.status == 0" type="success" size="small" @click="confirm_plan">确认</el-button>
                             <el-button v-if="plan.status != 3" type="danger" size="small" @click="close_plan">关闭</el-button>
-                            <el-button v-if="plan.status != 0" size="small" type="warning" @click="rollback_plan">回退</el-button>
+                            <el-button v-if="plan.status != 0 && order_refunds_allowed" size="small" type="warning" @click="rollback_plan">回退</el-button>
                             <el-button v-if="plan.status == 1 && !plan.is_buy" size="small" type="success" @click="pay_plan">验款</el-button>
                         </span>
                         <el-button v-permission="['scale']" v-if="(plan.status == 2) || (plan.status == 1 && plan.is_buy)" type="primary" size="small">发车</el-button>
@@ -239,6 +239,7 @@ export default {
             show_order_verify: false,
             show_fc_execute: false,
             show_sc_exe: true,
+            order_refunds_allowed: false,
             update_input_rules: {
                 main_vehicle_plate: [{
                     pattern: /^[京津沪渝冀豫云辽黑湘皖鲁新苏浙赣鄂桂甘晋蒙陕吉闽贵粤青藏川宁琼使领A-Z]{1}[A-Z]{1}[A-Z0-9]{4}[A-Z0-9挂学警港澳]{1}$/,
@@ -493,6 +494,10 @@ export default {
             })
             this.$emit('refresh');
         },
+        get_order_refunds_config: async function () {
+            let ret = await this.$send_req('/global/get_is_allowed_order_return', {});
+            this.order_refunds_allowed = ret.is_allowed_order_return;
+        },
         preview_company_attach: function () {
             this.pics = [];
             if (this.plan.company.attachment) {
@@ -538,6 +543,7 @@ export default {
     },
     mounted: function () {
         this.init_contract();
+        this.get_order_refunds_config();
     },
 }
 </script>

--- a/mt_pc/src/components/OrderShowTable.vue
+++ b/mt_pc/src/components/OrderShowTable.vue
@@ -59,7 +59,14 @@
                             <el-tag size="mini" :type="scope.row.enter_time?'success':'info'">{{!!scope.row.enter_time?'已入场':'未入场'}}</el-tag>
                         </template>
                     </el-table-column>
-                    <el-table-column min-width="50" prop="stuff.name" label="物料">
+                    <el-table-column min-width="50" prop="stuff.name" label="物料" width="220">
+                        <template slot-scope="scope">
+                            {{scope.row.stuff.name}}
+                            <el-tag v-if="is_the_order_display_price && scope.row.unit_price" size="mini" type="warning">
+                                单价:{{scope.row.unit_price}}
+                                <span v-if="scope.row.count != 0">(总价:{{(scope.row.unit_price * scope.row.count).toFixed(2)}})</span>
+                            </el-tag>
+                        </template>
                     </el-table-column>
                     <el-table-column min-width="70" label="状态">
                         <template slot-scope="scope">
@@ -143,6 +150,7 @@ export default {
             stuff_id: 0,
             company_id: 0,
             company_search_input: '',
+            is_the_order_display_price: false,
             status_string: function (status) {
                 let status_array = ['未确认', '未付款', '未发车', '已关闭'];
                 let index = status;
@@ -354,9 +362,19 @@ export default {
                 this.refresh_order();
             });
         },
+        get_price_display_config: async function () {
+            try {
+                const result = await this.$send_req('/global/get_the_order_display_price', {});
+                this.is_the_order_display_price = result.is_the_order_display_price;
+            } catch (error) {
+                console.error('获取价格显示配置失败:', error);
+                this.is_the_order_display_price = false;
+            }
+        },
     },
     mounted: function () {
         this.reset_filter();
+        this.get_price_display_config();
     }
 
 }

--- a/mt_pc/src/views/stuff/GlobalStrategy.vue
+++ b/mt_pc/src/views/stuff/GlobalStrategy.vue
@@ -47,6 +47,10 @@
                     <el-switch v-model="support_location_detail" active-text="卸车地点支持细节输入" @change="set_support_location_detail">
                     </el-switch>
                 </vue-cell>
+                <vue-cell width="3of12">
+                    <el-switch v-model="is_allowed_order_return" active-text="是否允许订单回退" @change="set_is_allowed_order_return">
+                    </el-switch>
+                </vue-cell>
             </vue-grid>
             <h3>代理配置</h3>
             <page-content ref="all_delegates" body_key="delegates" enable req_url="/stuff/get_delegates">
@@ -199,6 +203,7 @@ export default {
             access_control_permission: false,
             barriergate_control_permission: false,
             support_location_detail: false,
+            is_allowed_order_return: false,
             contract_id_selected: 0,
             focus_delegate_id: 0,
             new_delegate: {
@@ -248,6 +253,7 @@ export default {
         this.get_access_control_permission();
         this.get_support_location_detail();
         this.get_barriergate_control_permission();
+        this.get_is_allowed_order_return();
     },
     methods: {
         add_extra_info_config: async function () {
@@ -498,8 +504,17 @@ export default {
         get_barriergate_control_permission: async function () {
             let ret = await this.$send_req('/global/get_barriergate_control_permission', {});
             this.barriergate_control_permission = ret.barriergate_control_permission;
+        },
+        get_is_allowed_order_return: async function () {
+            let ret = await this.$send_req('/global/get_is_allowed_order_return', {});
+            this.is_allowed_order_return = ret.is_allowed_order_return;
+        },
+        set_is_allowed_order_return: async function () {
+            await this.$send_req('/stuff/set_is_allowed_order_return', {
+                is_allowed_order_return: this.is_allowed_order_return
+            });
+        },
     }
-}
 }
 </script>
 

--- a/mt_pc/src/views/stuff/GlobalStrategy.vue
+++ b/mt_pc/src/views/stuff/GlobalStrategy.vue
@@ -48,6 +48,10 @@
                     </el-switch>
                 </vue-cell>
                 <vue-cell width="3of12">
+                    <el-switch v-model="is_the_order_display_price" active-text="订单列表是否显示价格" @change="set_the_order_display_price">
+                    </el-switch>
+                </vue-cell>
+                <vue-cell width="3of12">
                     <el-switch v-model="is_allowed_order_return" active-text="是否允许订单回退" @change="set_is_allowed_order_return">
                     </el-switch>
                 </vue-cell>
@@ -202,6 +206,7 @@ export default {
             ticket_hasOrhasnt_place: false,
             access_control_permission: false,
             barriergate_control_permission: false,
+            is_the_order_display_price: false,
             support_location_detail: false,
             is_allowed_order_return: false,
             contract_id_selected: 0,
@@ -253,6 +258,7 @@ export default {
         this.get_access_control_permission();
         this.get_support_location_detail();
         this.get_barriergate_control_permission();
+        this.get_the_order_display_price();
         this.get_is_allowed_order_return();
     },
     methods: {
@@ -505,6 +511,15 @@ export default {
             let ret = await this.$send_req('/global/get_barriergate_control_permission', {});
             this.barriergate_control_permission = ret.barriergate_control_permission;
         },
+        get_the_order_display_price: async function () {
+            let ret = await this.$send_req('/global/get_the_order_display_price', {});
+            this.is_the_order_display_price = ret.is_the_order_display_price;
+        },
+        set_the_order_display_price: async function () {
+            await this.$send_req('/stuff/set_the_order_display_price', {
+                is_the_order_display_price: this.is_the_order_display_price
+            });
+            },
         get_is_allowed_order_return: async function () {
             let ret = await this.$send_req('/global/get_is_allowed_order_return', {});
             this.is_allowed_order_return = ret.is_allowed_order_return;
@@ -513,8 +528,8 @@ export default {
             await this.$send_req('/stuff/set_is_allowed_order_return', {
                 is_allowed_order_return: this.is_allowed_order_return
             });
-        },
-    }
+        },,
+        }
 }
 </script>
 


### PR DESCRIPTION
全局配置处增加一个开关：订单列表是否显示价格
订单列表处判断plan.stuff.company.是否显示价格的开关，该开关打开时才显示价格
plan.count  != 0时计算并显示总价，两位小数
<img width="340" height="150" alt="image" src="https://github.com/user-attachments/assets/c893cb1d-462a-4e83-9255-6f7aae0c29db" />
<img width="404" height="160" alt="image" src="https://github.com/user-attachments/assets/1f2b9f97-55f2-4dfe-bd60-de4f8051680f" />
<img width="340" height="145" alt="image" src="https://github.com/user-attachments/assets/5c0044a8-ae11-42e4-820b-0147320cee46" />
