### PR TITLE
ZYZL-579-订单回退的功能添加全局开关

### DIFF
--- a/api/db_opt.js
+++ b/api/db_opt.js
@@ -127,6 +127,7 @@ let db_opt = {
             access_control_permission: { type: DataTypes.BOOLEAN, defaultValue: false },
             support_location_detail: { type: DataTypes.BOOLEAN, defaultValue: false },
             barriergate_control_permission: { type: DataTypes.BOOLEAN, defaultValue: false },
+            is_allowed_order_return: { type: DataTypes.BOOLEAN, defaultValue: false },
         },
         plan: {
             id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },

--- a/api/module/global_module.js
+++ b/api/module/global_module.js
@@ -126,7 +126,7 @@ async function checkif_plan_checkinable(plan, driver, lat, lon) {
 }
 module.exports = {
     name: 'global',
-    description: '全局',
+    description: '全局',    
     methods: {
         driver_phone_online: {
             name: '司机手机号上线',
@@ -2049,6 +2049,20 @@ module.exports = {
             func: async function (body, token) {
                 let company = await rbac_lib.get_company_by_token(token);
                 return { barriergate_control_permission: company.barriergate_control_permission };
+            }
+        },
+        get_is_allowed_order_return: {
+            name: '获取是否允许订单回退',
+            description: '获取是否允许订单回退',
+            is_write: false,
+            is_get_api: false,
+            params: {},
+            result: {
+                is_allowed_order_return: { type: Boolean, mean: '是否允许订单回退', example: true }
+            },
+            func: async function (body, token) {
+                let company = await rbac_lib.get_company_by_token(token);
+                return { is_allowed_order_return: company.is_allowed_order_return };
             }
         },
         get_support_location_detail: {

--- a/api/module/stuff_module.js
+++ b/api/module/stuff_module.js
@@ -1380,7 +1380,27 @@ module.exports = {
                 return { result: true };
             }
         },
-        set_delay_checkout_time: {
+        set_is_allowed_order_return: {
+            name: '设置是否允许订单回退',
+            description: '设置是否允许订单回退',
+            is_write: true,
+            is_get_api: false,
+            params: {
+                is_allowed_order_return: { type: Boolean, have_to: true, mean: '是否允许订单回退', example: true }
+            },
+            result: {
+                result: { type: Boolean, mean: '结果', example: true }
+            },
+            func: async function (body, token) {
+                let company = await rbac_lib.get_company_by_token(token);
+                if (company) {
+                    company.is_allowed_order_return = body.is_allowed_order_return;
+                    await company.save();
+                }
+                return { result: true };
+            }
+        },
+        set_delay_checkout_time: {  
             name: '设置延迟结算定时时间',
             description: '设置延迟结算定时时间',
             is_write: true,

--- a/mt_gui/src/pages/OrderList.vue
+++ b/mt_gui/src/pages/OrderList.vue
@@ -171,7 +171,7 @@
                             <fui-button v-if="focus_plan.status != 3 && plan_owner" btnSize="mini" text="取消" type="danger" @click="prepare_xxx_confirm(cur_cancel_url, '取消')"></fui-button>
                             <module-filter :rm_array="['sale_management', 'buy_management']" style="display:flex;">
                                 <fui-button v-if="focus_plan.status == 0" btnSize="mini" type="success" text="确认" @click="prepare_xxx_confirm(cur_confirm_url, '确认')"></fui-button>
-                                <fui-button v-if="focus_plan.status != 0" btnSize="mini" type="warning" text="回退" @click="show_rollback_confirm = true;"></fui-button>
+                                <fui-button v-if="focus_plan.status != 0 && is_allowed_order_return" btnSize="mini" type="warning" text="回退" @click="show_rollback_confirm = true;"></fui-button>
                                 <fui-button v-if="focus_plan.status != 3" btnSize="mini" type="danger" text="关闭" @click="prepare_xxx_confirm(cur_close_url, '关闭')"></fui-button>
                                 <fui-button v-if="(focus_plan.status == 1 && !focus_plan.is_buy)" btnSize="mini" type="success" text="验款" @click="prepare_pay_confirm('验款')"></fui-button>
                             </module-filter>
@@ -615,7 +615,8 @@ export default {
             deliver_time_type: '',
             tabs: [],
             show_batch_copy: false,
-            gallery_index: 0
+            gallery_index: 0,
+            is_allowed_order_return: false,
         }
     },
     computed: {
@@ -882,6 +883,10 @@ export default {
                 this.refresh_plans();
             }
             this.show_batch_copy = false;
+        },
+        get_is_allowed_order_return: async function () {
+            let ret = await this.$send_req('/global/get_is_allowed_order_return', {});
+            this.is_allowed_order_return = ret.is_allowed_order_return;
         },
         pick_address: function (e) {
             this.dup_plan.drop_address = e.map(item => item.name).join('-')
@@ -1455,6 +1460,7 @@ export default {
         tom.setDate(tom.getDate() + 1);
         this.default_time = utils.dateFormatter(tom, 'y-m-d', 4, false);
         this.init_number_of_sold_plan();
+        this.get_is_allowed_order_return();
     },
 }
 </script>

--- a/mt_pc/src/components/OrderDetail.vue
+++ b/mt_pc/src/components/OrderDetail.vue
@@ -1,4 +1,4 @@
-<template>
+                <template>
 <div>
     <vue-grid align="stretch" justify="around">
         <vue-cell width="12of12">
@@ -46,7 +46,7 @@
                         <span v-if="has_plan_reciever_permission">
                             <el-button v-if="plan.status == 0" type="success" size="small" @click="confirm_plan">确认</el-button>
                             <el-button v-if="plan.status != 3" type="danger" size="small" @click="close_plan">关闭</el-button>
-                            <el-button v-if="plan.status != 0" size="small" type="warning" @click="rollback_plan">回退</el-button>
+                            <el-button v-if="plan.status != 0 && order_refunds_allowed" size="small" type="warning" @click="rollback_plan">回退</el-button>
                             <el-button v-if="plan.status == 1 && !plan.is_buy" size="small" type="success" @click="pay_plan">验款</el-button>
                         </span>
                         <el-button v-permission="['scale']" v-if="(plan.status == 2) || (plan.status == 1 && plan.is_buy)" type="primary" size="small">发车</el-button>
@@ -239,6 +239,7 @@ export default {
             show_order_verify: false,
             show_fc_execute: false,
             show_sc_exe: true,
+            order_refunds_allowed: false,
             update_input_rules: {
                 main_vehicle_plate: [{
                     pattern: /^[京津沪渝冀豫云辽黑湘皖鲁新苏浙赣鄂桂甘晋蒙陕吉闽贵粤青藏川宁琼使领A-Z]{1}[A-Z]{1}[A-Z0-9]{4}[A-Z0-9挂学警港澳]{1}$/,
@@ -493,6 +494,10 @@ export default {
             })
             this.$emit('refresh');
         },
+        get_order_refunds_config: async function () {
+            let ret = await this.$send_req('/global/get_is_allowed_order_return', {});
+            this.order_refunds_allowed = ret.is_allowed_order_return;
+        },
         preview_company_attach: function () {
             this.pics = [];
             if (this.plan.company.attachment) {
@@ -538,6 +543,7 @@ export default {
     },
     mounted: function () {
         this.init_contract();
+        this.get_order_refunds_config();
     },
 }
 </script>

--- a/mt_pc/src/views/stuff/GlobalStrategy.vue
+++ b/mt_pc/src/views/stuff/GlobalStrategy.vue
@@ -47,6 +47,10 @@
                     <el-switch v-model="support_location_detail" active-text="卸车地点支持细节输入" @change="set_support_location_detail">
                     </el-switch>
                 </vue-cell>
+                <vue-cell width="3of12">
+                    <el-switch v-model="is_allowed_order_return" active-text="是否允许订单回退" @change="set_is_allowed_order_return">
+                    </el-switch>
+                </vue-cell>
             </vue-grid>
             <h3>代理配置</h3>
             <page-content ref="all_delegates" body_key="delegates" enable req_url="/stuff/get_delegates">
@@ -199,6 +203,7 @@ export default {
             access_control_permission: false,
             barriergate_control_permission: false,
             support_location_detail: false,
+            is_allowed_order_return: false,
             contract_id_selected: 0,
             focus_delegate_id: 0,
             new_delegate: {
@@ -248,6 +253,7 @@ export default {
         this.get_access_control_permission();
         this.get_support_location_detail();
         this.get_barriergate_control_permission();
+        this.get_is_allowed_order_return();
     },
     methods: {
         add_extra_info_config: async function () {
@@ -498,8 +504,17 @@ export default {
         get_barriergate_control_permission: async function () {
             let ret = await this.$send_req('/global/get_barriergate_control_permission', {});
             this.barriergate_control_permission = ret.barriergate_control_permission;
+        },
+        get_is_allowed_order_return: async function () {
+            let ret = await this.$send_req('/global/get_is_allowed_order_return', {});
+            this.is_allowed_order_return = ret.is_allowed_order_return;
+        },
+        set_is_allowed_order_return: async function () {
+            await this.$send_req('/stuff/set_is_allowed_order_return', {
+                is_allowed_order_return: this.is_allowed_order_return
+            });
+        },
     }
-}
 }
 </script>
 


### PR DESCRIPTION
全局策略增加配置项：是否允许订单回退
在手机和PC的订单详情页中，根据plan.stuff.company.允许开关  显示回退按钮
<img width="313" height="140" alt="image" src="https://github.com/user-attachments/assets/4a6834e3-7c77-479c-ada2-1aba5a8daacc" />
<img width="304" height="113" alt="image" src="https://github.com/user-attachments/assets/e21ab35d-8769-435f-8394-990ecea6b080" />
<img width="346" height="200" alt="image" src="https://github.com/user-attachments/assets/4df51a3e-c1de-4b92-b2f0-438bde137d6a" />
