### PR TITLE
ZYZL-581-PC端和小程序上现场管理的排队界面增加是否只显示未排号车辆的过滤开关

### DIFF
--- a/api/lib/plan_lib.js
+++ b/api/lib/plan_lib.js
@@ -1189,7 +1189,7 @@ module.exports = {
         }
         return ret;
     },
-    get_wait_que: async function (pageNo, token, include_license = false) {
+    get_wait_que: async function (pageNo, token, include_license = false, only_show_uncalled = false) {
         let sq = db_opt.get_sq();
         let stuff_array = [0];
         let company = await rbac_lib.get_company_by_token(token);
@@ -1214,6 +1214,11 @@ module.exports = {
         if (!include_license) {
             cond[db_opt.Op.and].push(
                 { register_time: { [db_opt.Op.ne]: null } },
+            );
+        }
+        if (only_show_uncalled) {
+            cond[db_opt.Op.and].push(
+                { call_time: null },
             );
         }
         let plans = await sq.models.plan.findAll({

--- a/api/module/scale_module.js
+++ b/api/module/scale_module.js
@@ -42,12 +42,13 @@ module.exports = {
             is_get_api: true,
             params: {
                 include_license: { type: Boolean, have_to: false, mean: '是否包含证件检查', example: true },
+                only_show_uncalled: { type: Boolean, have_to: false, mean: '仅显示未叫号', example: true },
             },
             result: {
                 plans: { type: Array, mean: '计划列表', explain: api_param_result_define.plan_detail_define }
             },
             func: async function (body, token) {
-                let ret = await plan_lib.get_wait_que(body.pageNo, token, body.include_license);
+                let ret = await plan_lib.get_wait_que(body.pageNo, token, body.include_license, body.only_show_uncalled);
                 return {
                     plans: ret.rows,
                     total: ret.count

--- a/mt_gui/src/subPage1/Field.vue
+++ b/mt_gui/src/subPage1/Field.vue
@@ -2,7 +2,7 @@
 <view>
     <u-subsection :list="sub_pages" :current="cur_page" @change="sectionChange"></u-subsection>
     <view v-if="cur_page == 0">
-        <list-show ref="plans" :fetch_function="get_wait_que" height="85vh" search_key="search_cond" v-model="plans" :fetch_params="[show_sc_in_field]">
+        <list-show ref="plans" :fetch_function="get_wait_que" height="85vh" search_key="search_cond" v-model="plans" :fetch_params="[show_sc_in_field,only_show_uncalled]">
             <view style="padding: 15rpx 20rpx; background-color: #f8f9fa; border-radius: 8rpx; margin: 10rpx; display: flex; align-items: center; justify-content: space-between; box-shadow: 0 2rpx 8rpx rgba(0,0,0,0.1);">
                 <view style="display: flex; align-items: center;">
                     <fui-icon name="filter" size="32" color="#666"></fui-icon>
@@ -18,7 +18,7 @@
                     </u-switch>
                 </view>
             </view>
-            <view v-for="item in filtered_plans" :key="item.id" class="single_card_show">
+            <view v-for="item in plans" :key="item.id" class="single_card_show">
                 <u-cell :icon="icon_make(item)" :title="item.main_vehicle.plate + '-' + item.behind_vehicle.plate">
                     <view slot="label" style="display:flex; flex-direction: column;">
                         <fui-text :text="item.company.name" size="24"></fui-text>
@@ -133,11 +133,6 @@ export default {
             show_sc_in_field: false,
             only_show_uncalled: false,
         };
-    },
-    computed: {
-        filtered_plans() {
-            return this.plans || [];
-        }
     },
     methods: {
         prepare_sc_confirm: function (item) {
@@ -269,14 +264,14 @@ export default {
             }
             return ret;
         },
-        get_wait_que: async function (pageNo, [show_sc_in_field]) {
+        get_wait_que: async function (pageNo, [show_sc_in_field, only_show_uncalled]) {
             if (show_sc_in_field == undefined) {
                 return [];
             }
             let ret = await this.$send_req('/scale/wait_que', {
                 pageNo: pageNo,
                 include_license: show_sc_in_field,
-                only_show_uncalled: this.only_show_uncalled
+                only_show_uncalled: only_show_uncalled
             });
             ret.plans.forEach(ele => {
                 ele.search_cond = ele.main_vehicle.plate + ' ' + ele.behind_vehicle.plate;

--- a/mt_gui/src/subPage1/Field.vue
+++ b/mt_gui/src/subPage1/Field.vue
@@ -2,8 +2,23 @@
 <view>
     <u-subsection :list="sub_pages" :current="cur_page" @change="sectionChange"></u-subsection>
     <view v-if="cur_page == 0">
-        <list-show ref="plans" :fetch_function="get_wait_que" height="90vh" search_key="search_cond" v-model="plans" :fetch_params="[show_sc_in_field]">
-            <view v-for="item in plans" :key="item.id" class="single_card_show">
+        <list-show ref="plans" :fetch_function="get_wait_que" height="85vh" search_key="search_cond" v-model="plans" :fetch_params="[show_sc_in_field]">
+            <view style="padding: 15rpx 20rpx; background-color: #f8f9fa; border-radius: 8rpx; margin: 10rpx; display: flex; align-items: center; justify-content: space-between; box-shadow: 0 2rpx 8rpx rgba(0,0,0,0.1);">
+                <view style="display: flex; align-items: center;">
+                    <fui-icon name="filter" size="32" color="#666"></fui-icon>
+                    <fui-text text="过滤选项" size="28" color="#666" style="margin-left: 15rpx;"></fui-text>
+                </view>
+                <view style="display: flex; align-items: center;">
+                    <fui-text text="仅显示未叫号" size="28" color="#333" style="margin-right: 15rpx;"></fui-text>
+                    <u-switch
+                        v-model="only_show_uncalled"
+                        @change="filter_uncalled_vehicles"
+                        active-color="#007aff"
+                        inactive-color="#e5e5e5">
+                    </u-switch>
+                </view>
+            </view>
+            <view v-for="item in filtered_plans" :key="item.id" class="single_card_show">
                 <u-cell :icon="icon_make(item)" :title="item.main_vehicle.plate + '-' + item.behind_vehicle.plate">
                     <view slot="label" style="display:flex; flex-direction: column;">
                         <fui-text :text="item.company.name" size="24"></fui-text>
@@ -116,7 +131,19 @@ export default {
             show_zone_select: false,
             focus_plan: {},
             show_sc_in_field: false,
+            only_show_uncalled: false,
         };
+    },
+    computed: {
+        filtered_plans() {
+            if (!this.plans) return [];
+            return this.plans.filter(plan => {
+                if (this.only_show_uncalled) {
+                    return !plan.call_time;
+                }
+                return true;
+            });
+        }
     },
     methods: {
         prepare_sc_confirm: function (item) {
@@ -281,7 +308,7 @@ export default {
         init_sc_show_switch: async function () {
             this.show_sc_in_field = (await this.$send_req('/global/get_show_sc_in_field', {})).show_sc_in_field;
             this.$refs.sc_confirm.refresh();
-        }
+        },
     },
     onPullDownRefresh: function () {
         if (this.$refs.plans) {

--- a/mt_gui/src/subPage1/Field.vue
+++ b/mt_gui/src/subPage1/Field.vue
@@ -12,7 +12,7 @@
                     <fui-text text="仅显示未叫号" size="28" color="#333" style="margin-right: 15rpx;"></fui-text>
                     <u-switch
                         v-model="only_show_uncalled"
-                        @change="filter_uncalled_vehicles"
+                        @change="refresh_plans"
                         active-color="#007aff"
                         inactive-color="#e5e5e5">
                     </u-switch>
@@ -136,13 +136,7 @@ export default {
     },
     computed: {
         filtered_plans() {
-            if (!this.plans) return [];
-            return this.plans.filter(plan => {
-                if (this.only_show_uncalled) {
-                    return !plan.call_time;
-                }
-                return true;
-            });
+            return this.plans || [];
         }
     },
     methods: {
@@ -281,12 +275,18 @@ export default {
             }
             let ret = await this.$send_req('/scale/wait_que', {
                 pageNo: pageNo,
-                include_license: show_sc_in_field
+                include_license: show_sc_in_field,
+                only_show_uncalled: this.only_show_uncalled
             });
             ret.plans.forEach(ele => {
                 ele.search_cond = ele.main_vehicle.plate + ' ' + ele.behind_vehicle.plate;
             });
             return ret.plans;
+        },
+        refresh_plans() {
+            if (this.$refs.plans) {
+                this.$refs.plans.refresh();
+            }
         },
         copy_text: function (e) {
             $fui.getClipboardData(e, res => {

--- a/mt_pc/src/views/field/Queue.vue
+++ b/mt_pc/src/views/field/Queue.vue
@@ -1,18 +1,25 @@
 <template>
 <el-container>
     <el-header style="padding-top: 20px;">
-        <el-form>
+        <el-form :inline="true">
             <el-form-item style="width: 400px;">
                 <el-input v-model="search_key" placeholder="输入公司名称/车牌号/司机姓名/电话查询" clearable @clear="cancel_search">
                     <el-button slot="append" icon="el-icon-search" @click="do_search"></el-button>
                 </el-input>
+            </el-form-item>
+            <el-form-item>
+                <el-switch
+                    v-model="only_show_uncalled"
+                    active-text="仅显示未叫号"
+                    @change="filter_uncalled_vehicles">
+                </el-switch>
             </el-form-item>
         </el-form>
     </el-header>
     <el-main>
         <page-content ref="wait_que" :req_url="'/scale/wait_que'" :search_input="search_key" :search_key="['company.name', 'main_vehicle.plate', 'behind_vehicle.plate', 'driver.name', 'driver.phone']" body_key="plans" :req_body="{}" :enable="true">
             <template v-slot:default="scope">
-                <el-table :data="scope.content" height="80vh" table-layout="auto">
+                <el-table :data="filteredContent(scope.content)" height="80vh" table-layout="auto">
                     <el-table-column prop="register_number" label="序号" width="60">
                     </el-table-column>
                     <el-table-column prop="company.name" label="公司名称" width="120">
@@ -140,9 +147,19 @@ export default {
             zones: [],
             zone_name: '',
             focus_plan: {},
+            only_show_uncalled: false,
         };
     },
     methods: {
+        filteredContent(content) {
+            if (!content) return [];
+            return content.filter(plan => {
+                if (this.only_show_uncalled) {
+                    return !plan.call_time;
+                }
+                return true;
+            });
+        },
         init_dev: async function () {
             let resp = await this.$send_req('/scale/get_device_status', {});
             this.$set(this, 'all_dev', resp.devices);

--- a/mt_pc/src/views/field/Queue.vue
+++ b/mt_pc/src/views/field/Queue.vue
@@ -11,13 +11,13 @@
                 <el-switch
                     v-model="only_show_uncalled"
                     active-text="仅显示未叫号"
-                    @change="filter_uncalled_vehicles">
+                    @change="refresh_wait_que">
                 </el-switch>
             </el-form-item>
         </el-form>
     </el-header>
     <el-main>
-        <page-content ref="wait_que" :req_url="'/scale/wait_que'" :search_input="search_key" :search_key="['company.name', 'main_vehicle.plate', 'behind_vehicle.plate', 'driver.name', 'driver.phone']" body_key="plans" :req_body="{}" :enable="true">
+        <page-content ref="wait_que" :req_url="'/scale/wait_que'" :search_input="search_key" :search_key="['company.name', 'main_vehicle.plate', 'behind_vehicle.plate', 'driver.name', 'driver.phone']" body_key="plans" :req_body="{ only_show_uncalled: only_show_uncalled }" :enable="true">
             <template v-slot:default="scope">
                 <el-table :data="filteredContent(scope.content)" height="80vh" table-layout="auto">
                     <el-table-column prop="register_number" label="序号" width="60">
@@ -152,13 +152,7 @@ export default {
     },
     methods: {
         filteredContent(content) {
-            if (!content) return [];
-            return content.filter(plan => {
-                if (this.only_show_uncalled) {
-                    return !plan.call_time;
-                }
-                return true;
-            });
+            return content || [];
         },
         init_dev: async function () {
             let resp = await this.$send_req('/scale/get_device_status', {});
@@ -179,8 +173,10 @@ export default {
             this.$refs.wait_que.cancel_search();
         },
         refresh_wait_que() {
-            let cur_page = this.$refs.wait_que.cur_page;
-            this.$refs.wait_que.refresh(cur_page);
+            this.$nextTick(() => {
+                let cur_page = this.$refs.wait_que.cur_page;
+                this.$refs.wait_que.refresh(cur_page);
+            });
         },
 
         after_other_action(e) {


### PR DESCRIPTION
添加一个只显示未排号车辆的过滤开关
<img width="1118" height="725" alt="image" src="https://github.com/user-attachments/assets/022f4e6d-f9e0-4bd4-8743-894165366631" />
<img width="564" height="613" alt="image" src="https://github.com/user-attachments/assets/95d50bbf-2a08-43dd-92e7-7ac1ab47d483" />
