### PR TITLE
ZYZL-583-现场检查增加一次性签名特性

### DIFF
--- a/api/db_opt.js
+++ b/api/db_opt.js
@@ -67,6 +67,7 @@ let db_opt = {
             fixed: { type: DataTypes.BOOLEAN },
             prefer_order_begin_offset: { type: DataTypes.INTEGER, defaultValue: 0 },
             prefer_order_end_offset: { type: DataTypes.INTEGER, defaultValue: 1 },
+            signature_pic: { type: DataTypes.STRING },
         },
         global_replace_form : {
             id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },

--- a/api/index.js
+++ b/api/index.js
@@ -7,7 +7,6 @@ const jimp = require('jimp').default;
 const app = express();
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
-app.use('/uploads', express.static('/database/uploads'));
 app.help_info = [];
 if (!isMainThread) {
     const { pic_list } = workerData;
@@ -137,50 +136,6 @@ else {
         });
     });
     
-    // 专门的签名图片上传接口
-    app.post('/api/v1/upload_signature', upload.single('file'), (req, res) => {
-        const path = require('path');
-        const fs = require('fs');
-        const uuid = require('uuid');
-        
-        try {
-            // 确保上传目录存在
-            const uploadDir = '/database/uploads';
-            if (!fs.existsSync(uploadDir)) {
-                fs.mkdirSync(uploadDir, { recursive: true });
-                console.log('创建上传目录:', uploadDir);
-            }
-            
-            // 获取文件扩展名
-            let fileExtension = path.extname(req.file.originalname);
-            
-            // 生成唯一文件名
-            let real_file_name = uuid.v4();
-            const filePath = '/uploads/' + real_file_name + fileExtension;
-            const fullPath = '/database' + filePath;
-            
-            console.log('签名图片上传开始:', {
-                originalName: req.file.originalname,
-                tempPath: req.file.path,
-                targetPath: fullPath,
-                fileSize: req.file.size
-            });
-            
-            // 直接移动文件到目标位置，避免重复的读写操作
-            fs.renameSync(req.file.path, fullPath);
-            
-            console.log('签名图片上传成功:', filePath);
-            res.send(filePath);
-            
-        } catch (error) {
-            console.error('签名图片上传失败:', error);
-            // 清理临时文件
-            if (req.file && req.file.path && fs.existsSync(req.file.path)) {
-                fs.unlinkSync(req.file.path);
-            }
-            res.status(500).send({ err_msg: '签名图片上传失败: ' + error.message });
-        }
-    });
     app.post('/api/v1/merge_pics', async (req, res) => {
         let body = req.body;
         let pic_list = body.pic_list;

--- a/api/index.js
+++ b/api/index.js
@@ -7,6 +7,7 @@ const jimp = require('jimp').default;
 const app = express();
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+app.use('/uploads', express.static('/database/uploads'));
 app.help_info = [];
 if (!isMainThread) {
     const { pic_list } = workerData;
@@ -134,6 +135,51 @@ else {
             fs.writeFileSync('/database' + filePath, decodedData);
             res.send(filePath);
         });
+    });
+    
+    // 专门的签名图片上传接口
+    app.post('/api/v1/upload_signature', upload.single('file'), (req, res) => {
+        const path = require('path');
+        const fs = require('fs');
+        const uuid = require('uuid');
+        
+        try {
+            // 确保上传目录存在
+            const uploadDir = '/database/uploads';
+            if (!fs.existsSync(uploadDir)) {
+                fs.mkdirSync(uploadDir, { recursive: true });
+                console.log('创建上传目录:', uploadDir);
+            }
+            
+            // 获取文件扩展名
+            let fileExtension = path.extname(req.file.originalname);
+            
+            // 生成唯一文件名
+            let real_file_name = uuid.v4();
+            const filePath = '/uploads/' + real_file_name + fileExtension;
+            const fullPath = '/database' + filePath;
+            
+            console.log('签名图片上传开始:', {
+                originalName: req.file.originalname,
+                tempPath: req.file.path,
+                targetPath: fullPath,
+                fileSize: req.file.size
+            });
+            
+            // 直接移动文件到目标位置，避免重复的读写操作
+            fs.renameSync(req.file.path, fullPath);
+            
+            console.log('签名图片上传成功:', filePath);
+            res.send(filePath);
+            
+        } catch (error) {
+            console.error('签名图片上传失败:', error);
+            // 清理临时文件
+            if (req.file && req.file.path && fs.existsSync(req.file.path)) {
+                fs.unlinkSync(req.file.path);
+            }
+            res.status(500).send({ err_msg: '签名图片上传失败: ' + error.message });
+        }
     });
     app.post('/api/v1/merge_pics', async (req, res) => {
         let body = req.body;

--- a/api/lib/fc_lib.js
+++ b/api/lib/fc_lib.js
@@ -131,9 +131,6 @@ module.exports = {
                 include: [{
                     model: sq.models.fc_check_result,
                     include: [sq.models.field_check_item]
-                }, {
-                    model: sq.models.rbac_user,
-                    attributes: ['id', 'name', 'signature_pic', 'phone', 'email'] // 包含更多字段以确保完整性
                 }]
             });
             if (fc_plan_tables.length == 1) {
@@ -173,9 +170,6 @@ module.exports = {
                 let tmp = item.toJSON()
                 if (item.fc_plan_table) {
                     tmp.fc_plan_table = item.fc_plan_table.toJSON();
-                    if (item.fc_plan_table.rbac_user) {
-                        tmp.fc_plan_table.rbac_user = item.fc_plan_table.rbac_user.toJSON();
-                    }
                 }
                 ret.push(tmp);
             });

--- a/api/lib/fc_lib.js
+++ b/api/lib/fc_lib.js
@@ -248,10 +248,8 @@ module.exports = {
         const xmlContent = renderedZip.files['word/document.xml'].asText();
         
         if (fc_result.user_signature) {
-            const imagePath = path.resolve('/database' + fc_result.user_signature);
-            console.log('imagePath', imagePath);    
+            const imagePath = path.resolve('/database' + fc_result.user_signature);  
             if (fs.existsSync(imagePath)) {
-                console.log('imagePath', imagePath);
                 const imageBuffer = fs.readFileSync(imagePath);
                 
                 const imageFileName = `image_${uuid.v4().split('-')[0]}.png`;

--- a/api/lib/fc_lib.js
+++ b/api/lib/fc_lib.js
@@ -131,7 +131,7 @@ module.exports = {
                 include: [{
                     model: sq.models.fc_check_result,
                     include: [sq.models.field_check_item]
-                }]
+                },sq.models.rbac_user]
             });
             if (fc_plan_tables.length == 1) {
                 element.fc_plan_table = fc_plan_tables[0];
@@ -249,8 +249,9 @@ module.exports = {
         
         if (fc_result.user_signature) {
             const imagePath = path.resolve('/database' + fc_result.user_signature);
-            
+            console.log('imagePath', imagePath);    
             if (fs.existsSync(imagePath)) {
+                console.log('imagePath', imagePath);
                 const imageBuffer = fs.readFileSync(imagePath);
                 
                 const imageFileName = `image_${uuid.v4().split('-')[0]}.png`;

--- a/api/lib/fc_lib.js
+++ b/api/lib/fc_lib.js
@@ -386,10 +386,13 @@ module.exports = {
         const archive = archiver('zip', { zlib: { level: 9 } });
 
         output.on('close', async () => {
+            console.log('ZIP文件创建成功,大小:' + archive.pointer() + ' bytes');
+            // 删除打包前的文件
             await Promise.all(filePaths.map(async (filePath) => {
                 try {
                     const absolutePath = path.resolve(filePath);
                     await fs.promises.unlink(absolutePath);
+                    console.log(`文件已删除: ${absolutePath}`);
                 } catch (err) {
                     console.error(`无法删除文件 ${absolutePath}: ${err.message}`);
                 }
@@ -406,6 +409,7 @@ module.exports = {
             try {
                 const fileName = absolutePath.match(/fc_(.*)/)[1];
                 await archive.file(absolutePath, { name: `现场检查表_${fileName}` });
+                console.log(`文件已添加到ZIP: ${absolutePath}`);
             } catch (err) {
                 console.error(`无法访问文件 ${absolutePath}: ${err.message}`);
             }

--- a/api/lib/fc_lib.js
+++ b/api/lib/fc_lib.js
@@ -131,10 +131,14 @@ module.exports = {
                 include: [{
                     model: sq.models.fc_check_result,
                     include: [sq.models.field_check_item]
-                }, sq.models.rbac_user]
+                }, {
+                    model: sq.models.rbac_user,
+                    attributes: ['id', 'name', 'signature_pic', 'phone', 'email'] // 包含更多字段以确保完整性
+                }]
             });
             if (fc_plan_tables.length == 1) {
                 element.fc_plan_table = fc_plan_tables[0];
+
             }
         }
         return { fc_plan_tables: ret.fc_table, total: ret.total };
@@ -169,6 +173,9 @@ module.exports = {
                 let tmp = item.toJSON()
                 if (item.fc_plan_table) {
                     tmp.fc_plan_table = item.fc_plan_table.toJSON();
+                    if (item.fc_plan_table.rbac_user) {
+                        tmp.fc_plan_table.rbac_user = item.fc_plan_table.rbac_user.toJSON();
+                    }
                 }
                 ret.push(tmp);
             });
@@ -189,6 +196,18 @@ module.exports = {
             if (fc_plan_table.fc_plan_table.finish_time) {
                 ret.checker = fc_plan_table.fc_plan_table.rbac_user.name;
                 ret.finish_time = fc_plan_table.fc_plan_table.finish_time;
+                
+                try {
+                    const user = await sq.models.rbac_user.findByPk(fc_plan_table.fc_plan_table.rbac_user.id, {
+                        attributes: ['id', 'name', 'signature_pic']
+                    });
+                    
+                    if (user && user.signature_pic) {
+                        ret.user_signature = user.signature_pic;
+                    }
+                } catch (error) {
+                    console.error('查询用户信息失败:', error);
+                }
             }
             ret.table_name = fc_plan_table.name;
             ret.stuff_name = plan.stuff.name;
@@ -200,16 +219,18 @@ module.exports = {
             ret = undefined;
         }
 
+
         return ret;
     },
     make_file_by_fc_result: async function (fc_result, template_path) {
-        // 读取模板文件
+        if (!fs.existsSync(template_path)) {
+            throw new Error(`模板文件不存在: ${template_path}`);
+        }
+        
         const content = fs.readFileSync(template_path, 'binary');
 
-        // 创建PizZip实例
         const zip = new PizZip(content);
 
-        // 创建Docxtemplater实例
         const doc = new Docxtemplater(zip, {
             parser: tag => ({
                 get: s => s === '.' ? tag : tag.split('.').reduce((a, b) => a && a[b], s)
@@ -219,57 +240,156 @@ module.exports = {
                 serializer: XMLSerializer
             }
         });
-        // 填充模板
+        
         doc.setData(fc_result);
+        
         try {
-            // 渲染文档
             doc.render();
         } catch (error) {
-            console.error('Error rendering document:', error);
+            console.error('文档渲染失败:', error);
             throw error;
         }
 
-        // 生成新的Word文件
-        let filename = `fc_${fc_result.main_vehicle}-${fc_result.behind_vehicle}-${fc_result.finish_time}.docx`;
-        let download_path = path.resolve('/database/uploads/', filename);
-        const buf = doc.getZip().generate({ type: 'nodebuffer' });
-        fs.writeFileSync(download_path, buf);
-
-        console.log('Document generated successfully!');
-        return download_path;
-    },
-    export_fc: async function (plans) {
-        let ret = '';
-        let filePaths = [];
-        for (let index = 0; index < plans.length; index++) {
-            const plan = plans[index];
-            let fc_plan_tables = plan.fc_info;
-            for (let jndex = 0; jndex < fc_plan_tables.length; jndex++) {
-                const fc_plan_table = fc_plan_tables[jndex];
-                let fc_result_table = await this.make_fc_for_export(fc_plan_table, plan);
-                if (fc_result_table) {
-                    let template_path = fc_plan_table.template_path;
-                    if (template_path) {
-                        let tmp_doc = await this.make_file_by_fc_result(fc_result_table, '/database' + template_path);
-                        filePaths.push(tmp_doc);
+        const renderedZip = doc.getZip();
+        const xmlContent = renderedZip.files['word/document.xml'].asText();
+        
+        if (fc_result.user_signature) {
+            const imagePath = path.resolve('/database' + fc_result.user_signature);
+            
+            if (fs.existsSync(imagePath)) {
+                const imageBuffer = fs.readFileSync(imagePath);
+                
+                const imageFileName = `image_${uuid.v4().split('-')[0]}.png`;
+                
+                renderedZip.file(`word/media/${imageFileName}`, imageBuffer);
+                
+                const signatureImageXml = `
+                    <w:p>
+                        <w:r>
+                            <w:t>检查人签名：</w:t>
+                        </w:r>
+                    </w:p>
+                    <w:p>
+                        <w:r>
+                            <w:drawing>
+                                <wp:inline distT="0" distB="0" distL="0" distR="0">
+                                    <wp:extent cx="2000000" cy="1000000"/>
+                                    <wp:effectExtent l="0" t="0" r="0" b="0"/>
+                                    <wp:docPr id="1" name="签名图片"/>
+                                    <wp:cNvGraphicFramePr>
+                                        <a:graphicFrameLocks xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" noChangeAspect="1"/>
+                                    </wp:cNvGraphicFramePr>
+                                    <a:graphic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+                                        <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">
+                                            <pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">
+                                                <pic:nvPicPr>
+                                                    <pic:cNvPr id="0" name="签名图片"/>
+                                                    <pic:cNvPicPr/>
+                                                </pic:nvPicPr>
+                                                <pic:blipFill>
+                                                    <a:blip r:embed="rId${imageFileName.replace('.png', '')}"/>
+                                                    <a:stretch>
+                                                        <a:fillRect/>
+                                                    </a:stretch>
+                                                </pic:blipFill>
+                                                <pic:spPr>
+                                                    <a:xfrm>
+                                                        <a:off x="0" y="0"/>
+                                                        <a:ext cx="2000000" cy="1000000"/>
+                                                    </a:xfrm>
+                                                    <a:prstGeom prst="rect">
+                                                        <a:avLst/>
+                                                    </a:prstGeom>
+                                                </pic:spPr>
+                                            </pic:pic>
+                                        </a:graphicData>
+                                    </a:graphic>
+                                </wp:inline>
+                            </w:drawing>
+                        </w:r>
+                    </w:p>`;
+                
+                const endBodyIndex = xmlContent.lastIndexOf('</w:body>');
+                if (endBodyIndex !== -1) {
+                    const newXmlContent = xmlContent.substring(0, endBodyIndex) + signatureImageXml + xmlContent.substring(endBodyIndex);
+                    renderedZip.file('word/document.xml', newXmlContent);
+                    
+                    const relsPath = 'word/_rels/document.xml.rels';
+                    let relsContent = '';
+                    if (renderedZip.files[relsPath]) {
+                        relsContent = renderedZip.files[relsPath].asText();
+                    } else {
+                        relsContent = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"></Relationships>';
+                    }
+                    
+                    const relId = `rId${imageFileName.replace('.png', '')}`;
+                    const relEntry = `<Relationship Id="${relId}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/${imageFileName}"/>`;
+                    
+                    const endRelsIndex = relsContent.lastIndexOf('</Relationships>');
+                    if (endRelsIndex !== -1) {
+                        const newRelsContent = relsContent.substring(0, endRelsIndex) + relEntry + relsContent.substring(endRelsIndex);
+                        renderedZip.file(relsPath, newRelsContent);
                     }
                 }
             }
         }
 
+        let filename = `fc_${fc_result.main_vehicle}-${fc_result.behind_vehicle}-${fc_result.finish_time}.docx`;
+        let download_path = path.resolve('/database/uploads/', filename);
+        
+        const buf = renderedZip.generate({ type: 'nodebuffer' });
+        fs.writeFileSync(download_path, buf);
+
+        return download_path;
+    },
+    export_fc: async function (plans) {
+        let ret = '';
+        let filePaths = [];
+        
+        for (let index = 0; index < plans.length; index++) {
+            const plan = plans[index];
+            
+            let fc_plan_tables = plan.fc_info;
+            
+            if (!fc_plan_tables || fc_plan_tables.length === 0) {
+                continue;
+            }
+            
+            for (let jndex = 0; jndex < fc_plan_tables.length; jndex++) {
+                const fc_plan_table = fc_plan_tables[jndex];
+                
+                let fc_result_table = await this.make_fc_for_export(fc_plan_table, plan);
+                
+                if (fc_result_table) {
+                    let template_path = fc_plan_table.template_path;
+                    
+                    if (template_path) {
+                        let full_template_path = '/database' + template_path;
+                        
+                        if (fs.existsSync(full_template_path)) {
+                            let tmp_doc = await this.make_file_by_fc_result(fc_result_table, full_template_path);
+                            filePaths.push(tmp_doc);
+                        }
+                    }
+                }
+            }
+        }
+
+        if (filePaths.length === 0) {
+            return '';
+        }
+
         let download_path = `/uploads/fc_${uuid.v4().split('-')[0]}.zip`;
         const outputPath = `/database${download_path}`;
+        
         const output = fs.createWriteStream(outputPath);
         const archive = archiver('zip', { zlib: { level: 9 } });
 
         output.on('close', async () => {
-            console.log('ZIP文件创建成功,大小:' + archive.pointer() + ' bytes');
-            // 删除打包前的文件
             await Promise.all(filePaths.map(async (filePath) => {
                 try {
                     const absolutePath = path.resolve(filePath);
                     await fs.promises.unlink(absolutePath);
-                    console.log(`文件已删除: ${absolutePath}`);
                 } catch (err) {
                     console.error(`无法删除文件 ${absolutePath}: ${err.message}`);
                 }
@@ -286,7 +406,6 @@ module.exports = {
             try {
                 const fileName = absolutePath.match(/fc_(.*)/)[1];
                 await archive.file(absolutePath, { name: `现场检查表_${fileName}` });
-                console.log(`文件已添加到ZIP: ${absolutePath}`);
             } catch (err) {
                 console.error(`无法访问文件 ${absolutePath}: ${err.message}`);
             }

--- a/api/module/safe_check_module.js
+++ b/api/module/safe_check_module.js
@@ -377,7 +377,6 @@ module.exports = {
                 let user = await rbac_lib.get_user_by_token(token);
                 if (user) {
                     user.signature_pic = body.signature_pic;
-                    console.log(user.signature_pic);    
                     await user.save();
                     return { result: true };
                 } else {

--- a/api/module/safe_check_module.js
+++ b/api/module/safe_check_module.js
@@ -361,6 +361,49 @@ module.exports = {
                 return { result: true };
             },
         },
+        update_user_signature: {
+            name: '更新用户签名',
+            description: '更新用户签名图片',
+            need_rbac: false,
+            is_write: true,
+            is_get_api: false,
+            params: {
+                signature_pic: { type: String, have_to: true, mean: '签名图片路径', example: '/uploads/signature.png' }
+            },
+            result: {
+                result: { type: Boolean, mean: '更新结果', example: true }
+            },
+            func: async function (body, token) {
+                let user = await rbac_lib.get_user_by_token(token);
+                if (user) {
+                    user.signature_pic = body.signature_pic;
+                    console.log(user.signature_pic);    
+                    await user.save();
+                    return { result: true };
+                } else {
+                    throw { err_msg: '用户未找到' };
+                }
+            }
+        },
+        get_user_signature: {
+            name: '获取用户签名',
+            description: '获取用户签名图片',
+            need_rbac: false,
+            is_write: false,
+            is_get_api: false,
+            params: {},
+            result: {
+                signature_pic: { type: String, mean: '签名图片路径', example: '/uploads/signature.png' }
+            },
+            func: async function (body, token) {
+                let user = await rbac_lib.get_user_by_token(token);
+                if (user) {
+                    return { signature_pic: user.signature_pic || '' };
+                } else {
+                    throw { err_msg: '用户未找到' };
+                }
+            }
+        },
         commit_fc_plan: {
             name: '提交现场检查表',
             description: '提交现场检查表',

--- a/mt_gui/src/pages.json
+++ b/mt_gui/src/pages.json
@@ -140,10 +140,13 @@
 					"style": {
 						"enablePullDownRefresh": true
 					}
+				},
+				{
+					"path": "SignatureConfig"
 				}
 			]
 		}
-	],
+	],	
 	"globalStyle": {
 		"navigationBarTextStyle": "black",
 		"navigationBarTitleText": "掌易助理",

--- a/mt_gui/src/pages/Myself.vue
+++ b/mt_gui/src/pages/Myself.vue
@@ -59,6 +59,9 @@
         <module-filter require_module="rbac">
             <u-cell title="开发选项" isLink url="/pages/DevPage"></u-cell>
         </module-filter>
+        <fui-list-cell arrow @click="show_signature_config">
+            签名配置
+        </fui-list-cell>
     </fui-list>
     <fui-white-space></fui-white-space>
     <fui-button type="danger" text="退出登录" @click="unLogin"></fui-button>
@@ -205,6 +208,11 @@ export default {
         rebind: function () {
             uni.navigateTo({
                 url: '/subPage1/Bind'
+            });
+        },
+        show_signature_config: function () {
+            uni.navigateTo({
+                url: '/subPage1/SignatureConfig'
             });
         },
         config_role: function () {

--- a/mt_gui/src/subPage1/SignatureConfig.vue
+++ b/mt_gui/src/subPage1/SignatureConfig.vue
@@ -1,0 +1,160 @@
+<template>
+    <view class="signature-config-wrap">
+        <view style="margin-bottom: 32rpx; border: 2px solid #e0e0e0; border-radius: 8rpx; padding: 16rpx; background: #fafafa;">
+            <fui-autograph ref="autographRef" :width="width" :height="height" :background="background"
+                :lineWidth="lineWidth" :color="color" :tips="tips" @ready="() => { autographReady = true }" />
+        </view>
+        <view style="display: flex; justify-content: space-around;">
+            <fui-button text="重签" type="warning" btnSize="mini" @click="handleRedraw" />
+            <fui-button text="保存签名" type="primary" btnSize="mini" @click="handleSave" />
+            <fui-button text="清除签名" type="danger" btnSize="mini" @click="handleClear" />
+        </view>
+        <view v-if="imgUrl" style="margin-top: 32rpx; text-align: center;">
+            <fui-text text="签名图片预览" size="28" type="primary" />
+            <image :src="imgUrl" mode="widthFix"
+                style="width: 100%; max-width: 400px; margin-top: 16rpx; border: 1px solid #eee;" />
+        </view> 
+    </view>
+</template>
+
+<script>
+import FuiAutograph from '@/components/firstui/fui-autograph/fui-autograph.vue';
+export default {
+    name: 'SignatureConfig',
+    components: { FuiAutograph },
+    data() {
+        return {
+            width: 650,
+            height: 450,
+            background: '#e8e8e8',
+            lineWidth: 5,
+            color: '#181818',
+            tips: '请签名！',
+            imgUrl: '',
+            autographReady: false,
+        };
+    },
+    methods: {
+        handleAutographReady() {
+            this.autographReady = true;
+        },
+        async loadUserSignature() {
+            try {
+                // 获取用户已有的签名
+                const result = await this.$send_req('/sc/get_user_signature');
+                if (result && result.signature_pic) {
+                    this.imgUrl = this.$convert_attach_url(result.signature_pic).replace('http://localhost:8081', 'http://localhost:8080');
+                }
+            } catch (error) {
+                console.error('获取用户签名失败:', error);
+            }
+        },
+        handleRedraw() {
+            if (this.$refs.autographRef) {
+                this.$refs.autographRef.redraw();
+                this.imgUrl = '';
+            }
+        },
+        handleSave() {
+            if (this.$refs.autographRef) {
+                this.$refs.autographRef.drawComplete(async (imgPath) => {
+                    if (imgPath) {
+                        try {
+                            const uploadResult = await this.uploadSignatureImage(imgPath);
+                            if (uploadResult) {
+                                await this.saveSignatureToUser(uploadResult);
+                                this.imgUrl = this.$convert_attach_url(uploadResult);
+                                uni.showToast({
+                                    title: '签名保存成功',
+                                    icon: 'success'
+                                });
+                            }
+                        } catch (error) {
+                            console.error('保存签名失败:', error);
+                            uni.showToast({
+                                title: '保存失败',
+                                icon: 'none'
+                            });
+                        }
+                    } else {
+                        uni.showToast({
+                            title: '请先签名',
+                            icon: 'none'
+                        });
+                    }
+                });
+            }
+        },
+        async uploadSignatureImage(imgPath) {
+            return new Promise((resolve, reject) => {
+                uni.uploadFile({
+                    url: this.$remote_url() + '/api/v1/upload_signature',
+                    filePath: imgPath,
+                    name: 'file',
+                    header: {
+                        'token': uni.getStorageSync('token'),
+                    },
+                    success: (res) => {
+                        console.log('签名图片上传返回内容:', res.data);
+                        try {
+                            let filePath;
+                            if (typeof res.data === 'string') {
+                                try {
+                                    const data = JSON.parse(res.data);
+                                    filePath = data.file_path || data.url;
+                                } catch (e) {
+                                    filePath = res.data;
+                                }
+                            } else if (typeof res.data === 'object') {
+                                filePath = res.data.file_path || res.data.url;
+                            }
+                            if (filePath) {
+                                resolve(filePath);
+                            } else {
+                                reject(new Error('上传失败，未获取到文件路径'));
+                            }
+                        } catch (e) {
+                            reject(new Error('上传响应解析失败: ' + res.data));
+                        }
+                    },
+                    fail: (err) => {
+                        reject(err);
+                    }
+                });
+            });
+        },
+        async saveSignatureToUser(filePath) {
+                await this.$send_req('/sc/update_user_signature', {
+                signature_pic: filePath
+            });
+        },
+        async handleClear() {
+            try {
+                await this.$send_req('/sc/update_user_signature', {
+                    signature_pic: ''
+                });
+                this.imgUrl = '';
+                uni.showToast({
+                    title: '签名已清除',
+                    icon: 'success'
+                });
+            } catch (error) {
+                console.error('清除签名失败:', error);
+                uni.showToast({
+                    title: '清除失败',
+                    icon: 'none'
+                });
+            }
+        },
+    },
+    onLoad() {
+        this.loadUserSignature();
+    },
+};
+</script>
+
+<style scoped>
+.signature-config-wrap {
+    padding: 32rpx;
+}
+</style>

--- a/mt_gui/src/subPage1/SignatureConfig.vue
+++ b/mt_gui/src/subPage1/SignatureConfig.vue
@@ -43,7 +43,7 @@ export default {
                 // 获取用户已有的签名
                 const result = await this.$send_req('/sc/get_user_signature');
                 if (result && result.signature_pic) {
-                    this.imgUrl = this.$convert_attach_url(result.signature_pic).replace('http://localhost:8081', 'http://localhost:8080');
+                    this.imgUrl = this.$convert_attach_url(result.signature_pic);
                 }
             } catch (error) {
                 console.error('获取用户签名失败:', error);
@@ -88,7 +88,7 @@ export default {
         async uploadSignatureImage(imgPath) {
             return new Promise((resolve, reject) => {
                 uni.uploadFile({
-                    url: this.$remote_url() + '/api/v1/upload_signature',
+                    url: this.$remote_url() + '/api/v1/upload_file',
                     filePath: imgPath,
                     name: 'file',
                     header: {


### PR DESCRIPTION
在安检管理模块新增接口：update_user_signature/get_user_signature  用于维护用户自己的签名，保存为图片 在小程序的我的界面增加签名单元格，点击后要导航至签名维护界面，在该界面调用步骤1 中的两个接口，并显示签名图片 导出现场检查表的时候，若检查人有签名，则将签名图片放置到文件尾部
<img width="684" height="620" alt="image" src="https://github.com/user-attachments/assets/8e941a4c-8bab-4444-87d8-cfae5dd92245" />
<img width="488" height="660" alt="image" src="https://github.com/user-attachments/assets/38c0c801-7ce8-46ca-9d9b-28ebaaab31a8" />
<img width="1107" height="537" alt="image" src="https://github.com/user-attachments/assets/7e4b5033-9c46-4e61-ad99-b01066d85f3b" />
