### PR TITLE
ZYZL-589-在手机端和PC端的修改车辆信息界面增加承运公司的修改

### DIFF
--- a/api/lib/plan_lib.js
+++ b/api/lib/plan_lib.js
@@ -490,7 +490,7 @@ module.exports = {
         };
         return await this.searchPlansByModel(_company, where_condition, search_condition, this.replace_plan2archive.bind(this), false);
     },
-    update_single_plan: async function (_plan_id, _token, _plan_time, _main_vehicle_id, _behind_vehicle_id, _driver_id, _comment, _use_for, _drop_address, _trans_company_name) {
+    update_single_plan: async function (_plan_id, _token, _update_data) {
         let sq = db_opt.get_sq();
         let plan = await sq.models.plan.findByPk(_plan_id);
 
@@ -503,55 +503,55 @@ module.exports = {
         let company = await plan.getCompany();
         let owner_company = (await util_lib.get_single_plan_by_id(_plan_id)).stuff.company;
         // 判断是否在黑名单中
-        if (await this.is_in_blacklist(owner_company.id, _driver_id, _main_vehicle_id, _behind_vehicle_id)) {
+        if (await this.is_in_blacklist(owner_company.id, _update_data.driver_id, _update_data.main_vehicle_id, _update_data.behind_vehicle_id)) {
             throw { err_msg: '更新计划失败，司机或车辆已被列入黑名单' };
         }
         let opt_company = await rbac_lib.get_company_by_token(_token);
         if ((company && opt_company && company.id == opt_company.id) || (owner_company && opt_company && owner_company.id == opt_company.id)) {
             let change_comment = '';
-            if (_plan_time != undefined) {
-                change_comment += '计划时间由' + plan.plan_time + '改为' + _plan_time + ';\n';
-                plan.plan_time = _plan_time;
+            if (_update_data.plan_time != undefined) {
+                change_comment += '计划时间由' + plan.plan_time + '改为' + _update_data.plan_time + ';\n';
+                plan.plan_time = _update_data.plan_time;
             }
-            if (_main_vehicle_id != undefined) {
+            if (_update_data.main_vehicle_id != undefined) {
                 let orig_main_vehicle = await plan.getMain_vehicle();
-                let new_main_vehicle = await sq.models.vehicle.findByPk(_main_vehicle_id);
+                let new_main_vehicle = await sq.models.vehicle.findByPk(_update_data.main_vehicle_id);
                 if (orig_main_vehicle && new_main_vehicle) {
                     change_comment += '主车辆由' + orig_main_vehicle.plate + '改为' + new_main_vehicle.plate + ';\n';
                 }
                 plan.setMain_vehicle(new_main_vehicle);
             }
-            if (_behind_vehicle_id != undefined) {
+            if (_update_data.behind_vehicle_id != undefined) {
                 let orig_behind_vehicle = await plan.getBehind_vehicle();
-                let new_behind_vehicle = await sq.models.vehicle.findByPk(_behind_vehicle_id);
+                let new_behind_vehicle = await sq.models.vehicle.findByPk(_update_data.behind_vehicle_id);
                 if (orig_behind_vehicle && new_behind_vehicle) {
                     change_comment += '挂车辆由' + orig_behind_vehicle.plate + '改为' + new_behind_vehicle.plate + ';\n';
                 }
                 plan.setBehind_vehicle(new_behind_vehicle);
             }
-            if (_driver_id != undefined) {
+            if (_update_data.driver_id != undefined) {
                 let orig_driver = await plan.getDriver();
-                let new_driver = await sq.models.driver.findByPk(_driver_id);
+                let new_driver = await sq.models.driver.findByPk(_update_data.driver_id);
                 if (orig_driver && new_driver) {
                     change_comment += '司机电话由' + orig_driver.phone + '改为' + new_driver.phone + ';\n';
                 }
                 plan.setDriver(new_driver);
             }
-            if (_comment != undefined) {
-                change_comment += '备注由' + plan.comment + '改为' + _comment + ';\n';
-                plan.comment = _comment;
+            if (_update_data.comment != undefined) {
+                change_comment += '备注由' + plan.comment + '改为' + _update_data.comment + ';\n';
+                plan.comment = _update_data.comment;
             }
-            if (_use_for != undefined) {
-                change_comment += '用途由' + plan.use_for + '改为' + _use_for + ';\n';
-                plan.use_for = _use_for;
+            if (_update_data.use_for != undefined) {
+                change_comment += '用途由' + plan.use_for + '改为' + _update_data.use_for + ';\n';
+                plan.use_for = _update_data.use_for;
             }
-            if (_drop_address != undefined) {
-                change_comment += '卸货地址由' + plan.drop_address + '改为' + _drop_address + ';\n';
-                plan.drop_address = _drop_address;
+            if (_update_data.drop_address != undefined) {
+                change_comment += '卸货地址由' + plan.drop_address + '改为' + _update_data.drop_address + ';\n';
+                plan.drop_address = _update_data.drop_address;
             }
-            if (_trans_company_name != undefined) {
-                change_comment += '承运公司由' + plan.trans_company_name + '改为' + _trans_company_name + ';\n';
-                plan.trans_company_name = _trans_company_name;
+            if (_update_data.trans_company_name != undefined) {
+                change_comment += '承运公司由' + plan.trans_company_name + '改为' + _update_data.trans_company_name + ';\n';
+                plan.trans_company_name = _update_data.trans_company_name;
             }
             await plan.save();
             this.mark_dup_info(plan);

--- a/api/lib/plan_lib.js
+++ b/api/lib/plan_lib.js
@@ -490,7 +490,7 @@ module.exports = {
         };
         return await this.searchPlansByModel(_company, where_condition, search_condition, this.replace_plan2archive.bind(this), false);
     },
-    update_single_plan: async function (_plan_id, _token, _plan_time, _main_vehicle_id, _behind_vehicle_id, _driver_id, _comment, _use_for, _drop_address) {
+    update_single_plan: async function (_plan_id, _token, _plan_time, _main_vehicle_id, _behind_vehicle_id, _driver_id, _comment, _use_for, _drop_address, _trans_company_name) {
         let sq = db_opt.get_sq();
         let plan = await sq.models.plan.findByPk(_plan_id);
 
@@ -548,6 +548,10 @@ module.exports = {
             if (_drop_address != undefined) {
                 change_comment += '卸货地址由' + plan.drop_address + '改为' + _drop_address + ';\n';
                 plan.drop_address = _drop_address;
+            }
+            if (_trans_company_name != undefined) {
+                change_comment += '承运公司由' + plan.trans_company_name + '改为' + _trans_company_name + ';\n';
+                plan.trans_company_name = _trans_company_name;
             }
             await plan.save();
             this.mark_dup_info(plan);

--- a/api/module/common.js
+++ b/api/module/common.js
@@ -99,7 +99,16 @@ module.exports = {
                 let orig_driver = (await util_lib.get_single_plan_by_id(body.plan_id)).driver;
                 driver_id = (await plan_lib.fetch_driver(orig_driver.name, body.driver_phone, orig_driver.id_card)).id;
             }
-            await plan_lib.update_single_plan(body.plan_id, token, body.plan_time, main_vehicle_id, behind_vehicle_id, driver_id, body.comment, body.use_for, body.drop_address, body.trans_company_name);
+            await plan_lib.update_single_plan(body.plan_id, token, {
+                plan_time: body.plan_time,
+                main_vehicle_id: main_vehicle_id,
+                behind_vehicle_id: behind_vehicle_id,
+                driver_id: driver_id,
+                comment: body.comment,
+                use_for: body.use_for,
+                drop_address: body.drop_address,
+                trans_company_name: body.trans_company_name
+            });
             return { result: true };
         },
     },

--- a/api/module/common.js
+++ b/api/module/common.js
@@ -77,6 +77,7 @@ module.exports = {
             main_vehicle_plate: { type: String, have_to: false, mean: '主车车牌', example: '主车车牌' },
             behind_vehicle_plate: { type: String, have_to: false, mean: '挂车车牌', example: '挂车车牌' },
             driver_phone: { type: String, have_to: false, mean: '司机电话', example: '19999991111' },
+            trans_company_name: { type: String, have_to: false, mean: '承运公司', example: '承运公司名称' },
             comment: { type: String, have_to: false, mean: '备注', example: '备注' },
             use_for: { type: String, have_to: false, mean: '用途', example: '用途' },
             drop_address: { type: String, have_to: false, mean: '卸货地址', example: '卸货地址' },
@@ -98,7 +99,7 @@ module.exports = {
                 let orig_driver = (await util_lib.get_single_plan_by_id(body.plan_id)).driver;
                 driver_id = (await plan_lib.fetch_driver(orig_driver.name, body.driver_phone, orig_driver.id_card)).id;
             }
-            await plan_lib.update_single_plan(body.plan_id, token, body.plan_time, main_vehicle_id, behind_vehicle_id, driver_id, body.comment, body.use_for, body.drop_address);
+            await plan_lib.update_single_plan(body.plan_id, token, body.plan_time, main_vehicle_id, behind_vehicle_id, driver_id, body.comment, body.use_for, body.drop_address, body.trans_company_name);
             return { result: true };
         },
     },

--- a/mt_gui/src/pages/OrderList.vue
+++ b/mt_gui/src/pages/OrderList.vue
@@ -367,6 +367,7 @@
             <fui-input label="主车号" v-model="update_req.main_vehicle_plate"></fui-input>
             <fui-input label="挂车号" v-model="update_req.behind_vehicle_plate"></fui-input>
             <fui-input label="司机电话" v-model="update_req.driver_phone"></fui-input>
+            <fui-input label="承运公司" v-model="update_req.trans_company_name"></fui-input>
             <fui-input label="备注" v-model="update_req.comment"></fui-input>
         </fui-form>
     </fui-modal>
@@ -445,6 +446,7 @@ export default {
                 main_vehicle_plate: '',
                 behind_vehicle_plate: '',
                 driver_phone: '',
+                trans_company_name: '',
             },
             rollback_msg: '',
             use_for_array: [
@@ -823,6 +825,9 @@ export default {
                 if (this.update_req.driver_phone == this.focus_plan.driver.phone) {
                     delete this.update_req.driver_phone;
                 }
+                if (this.update_req.trans_company_name == (this.focus_plan.trans_company_name || '')) {
+                    delete this.update_req.trans_company_name;
+                }
                 if (this.update_req.comment == this.focus_plan.comment) {
                     delete this.update_req.comment;
                 }
@@ -838,6 +843,7 @@ export default {
             this.update_req.main_vehicle_plate = this.focus_plan.main_vehicle.plate;
             this.update_req.behind_vehicle_plate = this.focus_plan.behind_vehicle.plate;
             this.update_req.driver_phone = this.focus_plan.driver.phone;
+            this.update_req.trans_company_name = this.focus_plan.trans_company_name || '';
             this.update_req.comment = this.focus_plan.comment;
         },
         choose_use_for: function (_name) {

--- a/mt_pc/src/components/OrderDetail.vue
+++ b/mt_pc/src/components/OrderDetail.vue
@@ -143,6 +143,9 @@
             <el-form-item label="司机手机">
                 <el-input v-model="update_req.driver_phone"></el-input>
             </el-form-item>
+            <el-form-item label="承运公司">
+                <el-input v-model="update_req.trans_company_name" placeholder="请输入承运公司名称"></el-input>
+            </el-form-item>
             <el-form-item label="备注">
                 <el-input v-model="update_req.comment"></el-input>
             </el-form-item>
@@ -269,6 +272,7 @@ export default {
                 main_vehicle_plate: '',
                 behind_vehicle_plate: '',
                 driver_phone: '',
+                trans_company_name: '',
                 comment: '',
             },
             show_update: false,
@@ -365,6 +369,7 @@ export default {
                 main_vehicle_plate: this.plan.main_vehicle.plate,
                 behind_vehicle_plate: this.plan.behind_vehicle.plate,
                 driver_phone: this.plan.driver.phone,
+                trans_company_name: this.plan.trans_company_name || '',
                 comment: this.plan.comment,
             }
             this.show_update = true;
@@ -380,6 +385,9 @@ export default {
                     }
                     if (this.update_req.driver_phone == this.plan.driver.phone) {
                         delete this.update_req.driver_phone;
+                    }
+                    if (this.update_req.trans_company_name == (this.plan.trans_company_name || '')) {
+                        delete this.update_req.trans_company_name;
                     }
                     if (this.update_req.comment == this.plan.comment) {
                         delete this.update_req.comment;


### PR DESCRIPTION
1.移动端和pc添加承运公司的更新配置项
<img width="386" height="363" alt="image" src="https://github.com/user-attachments/assets/b78666a9-e1ce-4c86-93c0-83a14779b8ff" />
![Uploading image.png…]()
