### PR TITLE
ZYZL-591-装卸卸货地点选择处理错误-LNG物料对应的某个订单中出现了重烃物料配置的装卸货地点

### DIFF
--- a/mt_gui/src/subPage1/Field.vue
+++ b/mt_gui/src/subPage1/Field.vue
@@ -237,6 +237,7 @@ export default {
         prepare_confirm_vehicle: async function (item) {
             this.focus_plan_id = item.id;
             this.tmp_seal_no = item.seal_no;
+            this.zone_name = '';
             this.show_confirm_vehicle = true;
             this.focus_company = item.stuff.company;
             this.zones = item.stuff.drop_take_zones;
@@ -253,6 +254,8 @@ export default {
             });
             uni.startPullDownRefresh();
             this.show_confirm_vehicle = false;
+            this.zone_name = '';
+            this.tmp_seal_no = '';
         },
         icon_make: function (item) {
             let ret = 'hourglass';

--- a/mt_pc/src/views/field/Queue.vue
+++ b/mt_pc/src/views/field/Queue.vue
@@ -220,6 +220,7 @@ export default {
         prepare_confirm_vehicle: async function (item) {
             this.focus_plan_id = item.id;
             this.tmp_seal_no = item.seal_no;
+            this.zone_name = ''; 
             this.show_confirm_vehicle = true;
             this.focus_company = item.stuff.company;
             this.zones = item.stuff.drop_take_zones;
@@ -236,6 +237,8 @@ export default {
             });
             this.refresh_wait_que();
             this.show_confirm_vehicle = false;
+            this.zone_name = '';
+            this.tmp_seal_no = '';
         },
         call_vehicle: async function (item) {
             await this.$send_req('/scale/call_vehicle', {


### PR DESCRIPTION
1.修改mobile端装卸区域清除逻辑
2.修改pc端装卸区域清除逻辑
<img width="406" height="195" alt="image" src="https://github.com/user-attachments/assets/25df64c8-354a-4f4f-9fc4-08fcec114c47" />
第一次选择完区域后，清空
<img width="348" height="230" alt="image" src="https://github.com/user-attachments/assets/d3d96239-0032-467f-af6e-0b396a491114" />
保证第二次选择是重新选择