### PR TITLE
ZYZL-594-调价后-受到调价影响的订单要更新当前欠款额

### DIFF
--- a/api/module/stuff_module.js
+++ b/api/module/stuff_module.js
@@ -522,6 +522,44 @@ module.exports = {
                                 await plan_lib.record_plan_history(plan, (await rbac_lib.get_user_by_token(token)).name, comment, { transaction })
                                 // 更新价格
                                 plan.unit_price = unitPrice;
+                                if (plan.status == 1 && !plan.is_buy) {
+                                    let full_plan = await sq.models.plan.findOne({
+                                        where: { id: plan.id },
+                                        include: [
+                                            { model: sq.models.stuff, include: [{ model: sq.models.company }] },
+                                            { model: sq.models.company }
+                                        ],
+                                        transaction
+                                    });
+                                    let contracts = await full_plan.stuff.company.getSale_contracts({ 
+                                        where: { buyCompanyId: full_plan.company.id },
+                                        transaction 
+                                    });
+                                    let cur_balance = 0;
+                                    if (contracts.length == 1) {
+                                        cur_balance = contracts[0].balance;
+                                    }
+                                    let one_vehicle_cost = unitPrice * full_plan.stuff.expect_count;
+                                    let paid_vehicle_count = await full_plan.company.countPlans({
+                                        where: {
+                                            [db_opt.Op.and]: [
+                                                { status: 2 },
+                                                { stuffId: full_plan.stuff.id }
+                                            ]
+                                        },
+                                        transaction
+                                    });
+                                    let already_verified_cash = one_vehicle_cost * paid_vehicle_count;
+                                    let new_arrears = one_vehicle_cost - (cur_balance - already_verified_cash);
+                                    if (new_arrears <= 0) {
+                                        plan.arrears = 0;
+                                        plan.outstanding_vehicles = 0;
+                                    } else {
+                                        plan.arrears = new_arrears;
+                                        plan.outstanding_vehicles = paid_vehicle_count + 1;
+                                    }
+                                }
+                                
                                 await plan.save({ transaction });
                                 if (plan.status == 3) {
                                     setTimeout(async () => {


### PR DESCRIPTION
1.条件判断：只有当计划状态为1（未付款）且不是采购订单时，才需要重新计算欠额
2.获取合同余额：查询买卖双方的合同余额
3.计算单车成本：使用新的单价 × 预期装载量
4.计算已付款车辆数：统计该物料下已付款（状态为2）的车辆数量
5.重新计算欠额：使用与 verify_plan_pay 函数相同的计算逻辑
6.更新数据库：保存新的欠额和未付车辆数
![image](https://github.com/user-attachments/assets/aac53d1e-25fb-484c-ad15-36d706855e79)
![image](https://github.com/user-attachments/assets/e4c118f9-6e32-4b0b-bd8a-b321c28bde79)
