### PR TITLE
ZYZL-643-集团余额管理

### DIFF
--- a/api/lib/bidding_lib.js
+++ b/api/lib/bidding_lib.js
@@ -6,6 +6,7 @@ const officegen = require('officegen');
 const uuid = require('uuid');
 const fs = require('fs');
 const mcache = require('memory-cache');
+const plan_lib = require('./plan_lib');
 module.exports = {
     create_bidding: async function (stuff_id, total, comment, min, max, total_turn, pay_first, token, price_hide) {
         let sq = db_opt.get_sq();
@@ -161,7 +162,7 @@ module.exports = {
                         { model: sq.models.stuff, include: [sq.models.company] }]
                 });
                 if (buy_company && bc && bc.stuff && bc.stuff.company) {
-                    let contracts = await bc.stuff.company.getSale_contracts({ where: { buyCompanyId: buy_company.id } });
+                    let contracts = await plan_lib.get_sale_contracts_for_buyer_and_supply_company(buy_company.id, bc.stuff.company.id);
                     if (contracts.length == 1) {
                         let cur_balance = contracts[0].balance;
                         if (cur_balance >= bc.pay_first) {

--- a/api/lib/cash_lib.js
+++ b/api/lib/cash_lib.js
@@ -230,11 +230,7 @@ module.exports = {
                     }))[0];
                 }
                 else {
-                    contract = (await u8c_oi.company.getSale_contracts({
-                        where: {
-                            buyCompanyId: company.id,
-                        },
-                    }))[0];
+                    contract = (await plan_lib.get_sale_contracts_for_buyer_and_supply_company(company.id, u8c_oi.company.id))[0];
                 }
             }
 

--- a/api/lib/plan_lib.js
+++ b/api/lib/plan_lib.js
@@ -220,17 +220,7 @@ module.exports = {
         if (!company || !contract) {
             return false;
         }
-        if (await company.hasSale_contract(contract)) {
-            return true;
-        }
-        if (!company.parentGroupCompanyId) {
-            return false;
-        }
-        const parent_group = await db_opt.get_sq().models.company.findByPk(company.parentGroupCompanyId);
-        if (!parent_group) {
-            return false;
-        }
-        return await parent_group.hasSale_contract(contract);
+        return await company.hasSale_contract(contract);
     },
     contractOutOfDate: function (endDate) {
         let ret = false;

--- a/api/lib/plan_lib.js
+++ b/api/lib/plan_lib.js
@@ -116,7 +116,21 @@ module.exports = {
         return await sq.models.stuff.findAndCountAll({
             where: {
                 use_for_buy: false,
-                // '$contract.buyCompanyId$': _buy_company.id
+                [db_opt.Op.and]: [
+                    sq.literal(`EXISTS (
+                        SELECT 1 FROM contract c
+                        WHERE c.deletedAt IS NULL
+                          AND c.buyCompanyId = ${_buy_company.id}
+                          AND c.saleCompanyId = IFNULL((SELECT parentGroupCompanyId FROM company WHERE id = stuff.companyId), stuff.companyId)
+                          AND (
+                            (SELECT buy_config_hard FROM company WHERE id = stuff.companyId) = 0
+                            OR EXISTS (
+                                SELECT 1 FROM contract_stuff cs
+                                WHERE cs.stuffId = stuff.id AND cs.contractId = c.id
+                            )
+                          )
+                    )`)
+                ]
             },
             offset: pageNo * 20,
             limit: 20,
@@ -126,11 +140,6 @@ module.exports = {
             ],
             include: [
                 { model: sq.models.company, },
-                {
-                    model: sq.models.contract, where: {
-                        buyCompanyId: _buy_company.id
-                    }, required: true
-                }
             ]
         });
     },
@@ -178,6 +187,50 @@ module.exports = {
         if (exist_stuffs.length == 1) {
             await _contract.removeStuff(_stuff);
         }
+    },
+    get_sale_contract_owner_company_id: async function (sale_company_id, transaction = null) {
+        const sq = db_opt.get_sq();
+        const sale_company = await sq.models.company.findByPk(sale_company_id, {
+            ...(transaction && { transaction })
+        });
+        if (!sale_company) {
+            return null;
+        }
+        return sale_company.parentGroupCompanyId || sale_company.id;
+    },
+    get_sale_contracts_for_buyer_and_supply_company: async function (buy_company_id, supply_company_id, include_users = false, transaction = null) {
+        const sq = db_opt.get_sq();
+        const owner_company_id = await this.get_sale_contract_owner_company_id(supply_company_id, transaction);
+        if (!owner_company_id) {
+            return [];
+        }
+        const query_opt = {
+            where: {
+                saleCompanyId: owner_company_id,
+                buyCompanyId: buy_company_id
+            },
+            ...(transaction && { transaction })
+        };
+        if (include_users) {
+            query_opt.include = [sq.models.rbac_user];
+        }
+        return await sq.models.contract.findAll(query_opt);
+    },
+    has_sale_contract_operate_permission: async function (company, contract) {
+        if (!company || !contract) {
+            return false;
+        }
+        if (await company.hasSale_contract(contract)) {
+            return true;
+        }
+        if (!company.parentGroupCompanyId) {
+            return false;
+        }
+        const parent_group = await db_opt.get_sq().models.company.findByPk(company.parentGroupCompanyId);
+        if (!parent_group) {
+            return false;
+        }
+        return await parent_group.hasSale_contract(contract);
     },
     contractOutOfDate: function (endDate) {
         let ret = false;
@@ -629,7 +682,7 @@ module.exports = {
         let user = await rbac_lib.add_user(_phone);
         let company = await rbac_lib.get_company_by_token(_token);
         let contract = await sq.models.contract.findByPk(_contract_id);
-        if (contract && user && company && await company.hasSale_contract(contract)) {
+        if (contract && user && company && await this.has_sale_contract_operate_permission(company, contract)) {
             if (! await contract.hasRbac_user(user)) {
                 await contract.addRbac_user(user);
             }
@@ -643,7 +696,7 @@ module.exports = {
         let user = await rbac_lib.add_user(_phone);
         let company = await rbac_lib.get_company_by_token(_token);
         let contract = await sq.models.contract.findByPk(_contract_id);
-        if (contract && user && company && await company.hasSale_contract(contract)) {
+        if (contract && user && company && await this.has_sale_contract_operate_permission(company, contract)) {
             if (await contract.hasRbac_user(user)) {
                 await contract.removeRbac_user(user);
             }
@@ -673,7 +726,7 @@ module.exports = {
                 }
             }
 
-            let contracts = await plan.stuff.company.getSale_contracts({ where: { buyCompanyId: company_id } });
+            let contracts = await this.get_sale_contracts_for_buyer_and_supply_company(company_id, plan.stuff.company.id);
             let creator = await plan.getRbac_user();
             if (force || (creator && ((contracts.length == 1 && await contracts[0].hasRbac_user(creator)) || plan.is_buy))) {
                 plan.status = 1;
@@ -864,7 +917,7 @@ module.exports = {
         }, false, existing_t, allow_group_member_operate);
     },
     plan_cost: async function (plan) {
-        let contracts = await plan.stuff.company.getSale_contracts({ where: { buyCompanyId: plan.company.id } });
+        let contracts = await this.get_sale_contracts_for_buyer_and_supply_company(plan.company.id, plan.stuff.company.id);
         if (contracts.length == 1) {
             let contract = contracts[0];
             let decrease_cash = plan.unit_price * plan.count;
@@ -891,7 +944,7 @@ module.exports = {
         }
     },
     plan_undo_cost: async function (plan) {
-        let contracts = await plan.stuff.company.getSale_contracts({ where: { buyCompanyId: plan.company.id } });
+        let contracts = await this.get_sale_contracts_for_buyer_and_supply_company(plan.company.id, plan.stuff.company.id);
         if (contracts.length == 1) {
             let contract = contracts[0];
             let decrease_cash = plan.unit_price * plan.count;
@@ -1238,10 +1291,12 @@ module.exports = {
             return { arrears: 0, outstanding_vehicles: 0 };
         }
         const price_to_use = unit_price !== null ? unit_price : plan.unit_price;
-        let contracts = await plan.stuff.company.getSale_contracts({
-            where: { buyCompanyId: plan.company.id },
-            ...(transaction && { transaction })
-        });
+        let contracts = await this.get_sale_contracts_for_buyer_and_supply_company(
+            plan.company.id,
+            plan.stuff.company.id,
+            false,
+            transaction
+        );
         let cur_balance = 0;
         if (contracts.length == 1) {
             cur_balance = contracts[0].balance;

--- a/api/module/sale_management_module.js
+++ b/api/module/sale_management_module.js
@@ -105,7 +105,7 @@ module.exports = {
                 result: { type: Boolean, mean: '结果', example: true }
             },
             func: async function (body, token) {
-                await plan_lib.plan_rollback(body.plan_id, token, body.msg);
+                await plan_lib.plan_rollback(body.plan_id, token, body.msg, false, null, true);
                 return { result: true };
             }
         },
@@ -217,7 +217,7 @@ module.exports = {
                 let ret = { result: false };
                 let sale_company = await rbac_lib.get_company_by_token(token);
                 let contract = await db_opt.get_sq().models.contract.findByPk(body.contract_id);
-                if (contract && sale_company && await sale_company.hasSale_contract(contract)) {
+                if (contract && sale_company && await plan_lib.has_sale_contract_operate_permission(sale_company, contract)) {
                     await plan_lib.destroy_contract(contract.id);
                     ret.result = true;
                 }
@@ -235,17 +235,60 @@ module.exports = {
             result: common.contract_res_detail_define,
             func: async function (body, token) {
                 let company = await rbac_lib.get_company_by_token(token);
-                let contracts = await company.getSale_contracts({
-                    where: {
-                        buyCompanyId: body.customer_id
-                    },
-                    include: db_opt.get_sq().models.rbac_user
-                })
+                let contracts = await plan_lib.get_sale_contracts_for_buyer_and_supply_company(body.customer_id, company.id, true);
                 if (contracts.length != 1) {
                     throw { err_msg: "合同不存在" }
                 }
                 return contracts[0]
             },
+        },
+        get_stuff_for_contract: {
+            name: '获取合同可选货物',
+            description: '获取合同可选货物',
+            is_write: false,
+            is_get_api: true,
+            params: {},
+            result: {
+                stuff: {
+                    type: Array, mean: '货物', explain: {
+                        id: { type: Number, mean: '货物ID', example: 1 },
+                        name: { type: String, mean: '货物名', example: 'A公司-煤炭' },
+                        companyId: { type: Number, mean: '归属公司ID', example: 1 },
+                    }
+                }
+            },
+            func: async function (body, token) {
+                const sq = db_opt.get_sq();
+                const company = await rbac_lib.get_company_by_token(token);
+                if (!company) {
+                    return { stuff: [], total: 0 };
+                }
+                let company_ids = [company.id];
+                if (company.is_group) {
+                    const members = await company.getGroup_member_companies({ attributes: ['id'] });
+                    members.forEach((m) => {
+                        company_ids.push(m.id);
+                    });
+                }
+                const ret = await sq.models.stuff.findAndCountAll({
+                    where: {
+                        use_for_buy: false,
+                        companyId: {
+                            [db_opt.Op.in]: company_ids
+                        }
+                    },
+                    include: [{ model: sq.models.company }],
+                    order: [['companyId', 'ASC'], ['id', 'ASC']],
+                    offset: body.pageNo * 20,
+                    limit: 20,
+                });
+                ret.rows.forEach((item) => {
+                    if (item.companyId !== company.id) {
+                        item.name = `${item.company.name}-${item.name}`;
+                    }
+                });
+                return { stuff: ret.rows, total: ret.count };
+            }
         },
         contract_get: {
             name: '获取合同',
@@ -316,7 +359,12 @@ module.exports = {
                 let company = await rbac_lib.get_company_by_token(token);
                 let contract = await db_opt.get_sq().models.contract.findByPk(body.contract_id);
                 let stuff = await db_opt.get_sq().models.stuff.findByPk(body.stuff_id);
-                if (contract && stuff && company && await company.hasSale_contract(contract)) {
+                let stuff_company = stuff ? await stuff.getCompany() : null;
+                let can_use_stuff = !!(company && stuff_company && (
+                    stuff_company.id === company.id ||
+                    (company.is_group && stuff_company.parentGroupCompanyId === company.id)
+                ));
+                if (contract && stuff && company && can_use_stuff && await plan_lib.has_sale_contract_operate_permission(company, contract)) {
                     await plan_lib.add_stuff_to_contract(stuff, contract);
                     ret.result = true;
                 }
@@ -341,7 +389,12 @@ module.exports = {
                 let company = await rbac_lib.get_company_by_token(token);
                 let contract = await db_opt.get_sq().models.contract.findByPk(body.contract_id);
                 let stuff = await db_opt.get_sq().models.stuff.findByPk(body.stuff_id);
-                if (contract && stuff && company && await company.hasSale_contract(contract)) {
+                let stuff_company = stuff ? await stuff.getCompany() : null;
+                let can_use_stuff = !!(company && stuff_company && (
+                    stuff_company.id === company.id ||
+                    (company.is_group && stuff_company.parentGroupCompanyId === company.id)
+                ));
+                if (contract && stuff && company && can_use_stuff && await plan_lib.has_sale_contract_operate_permission(company, contract)) {
                     await plan_lib.del_stuff_from_contract(stuff, contract);
                     ret.result = true;
                 }

--- a/api/module/sale_management_module.js
+++ b/api/module/sale_management_module.js
@@ -235,6 +235,12 @@ module.exports = {
             result: common.contract_res_detail_define,
             func: async function (body, token) {
                 let company = await rbac_lib.get_company_by_token(token);
+                if (!company) {
+                    throw { err_msg: '无权限' };
+                }
+                if (!company.is_group) {
+                    throw { err_msg: '无权限' };
+                }
                 let contracts = await plan_lib.get_sale_contracts_for_buyer_and_supply_company(body.customer_id, company.id, true);
                 if (contracts.length != 1) {
                     throw { err_msg: "合同不存在" }
@@ -247,7 +253,9 @@ module.exports = {
             description: '获取合同可选货物',
             is_write: false,
             is_get_api: true,
-            params: {},
+            params: {
+                pageNo: { type: Number, have_to: false, mean: '页码（从0开始）', example: 0 },
+            },
             result: {
                 stuff: {
                     type: Array, mean: '货物', explain: {
@@ -255,7 +263,8 @@ module.exports = {
                         name: { type: String, mean: '货物名', example: 'A公司-煤炭' },
                         companyId: { type: Number, mean: '归属公司ID', example: 1 },
                     }
-                }
+                },
+                total: { type: Number, mean: '总条数', example: 1 },
             },
             func: async function (body, token) {
                 const sq = db_opt.get_sq();

--- a/automation/group/group_contract_member_flow.robot
+++ b/automation/group/group_contract_member_flow.robot
@@ -24,13 +24,22 @@ Group Contract Suite Reset
     Company Reset
 
 Setup Group Contract Scenario
-    ${parent}  Create One Company  gc_parent
-    ${member}  Create One Company  gc_member
-    ${buyer}  Create One Company  gc_buyer
+    ${suffix}  Evaluate  random.randint(100000, 999999)  modules=random
+    ${parent_name}  Set Variable  gc_parent_${suffix}
+    ${member_name}  Set Variable  gc_member_${suffix}
+    ${buyer_name}  Set Variable  gc_buyer_${suffix}
+    ${phone_tail}  Evaluate  random.randint(100, 999)  modules=random
+    ${parent_phone}  Set Variable  16610000${phone_tail}
+    ${member_phone}  Set Variable  16620000${phone_tail}
+    ${buyer_phone}  Set Variable  16630000${phone_tail}
 
-    ${parent_token}  Login As Admin Of Company  ${parent}[id]  ${PARENT_PHONE}  gc_parent_admin
-    ${member_token}  Login As Admin Of Company  ${member}[id]  ${MEMBER_PHONE}  gc_member_admin
-    ${buyer_token}  Login As Admin Of Company  ${buyer}[id]  ${BUYER_PHONE}  gc_buyer_admin
+    ${parent}  Create One Company  ${parent_name}
+    ${member}  Create One Company  ${member_name}
+    ${buyer}  Create One Company  ${buyer_name}
+
+    ${parent_token}  Login As Admin Of Company  ${parent}[id]  ${parent_phone}  gc_parent_admin_${suffix}
+    ${member_token}  Login As Admin Of Company  ${member}[id]  ${member_phone}  gc_member_admin_${suffix}
+    ${buyer_token}  Login As Admin Of Company  ${buyer}[id]  ${buyer_phone}  gc_buyer_admin_${suffix}
 
     ${parent_self}  Get Self Info  ${parent_token}
     Convert To Group By Super Admin  ${parent}[id]  ${parent_self}[id]
@@ -41,15 +50,15 @@ Setup Group Contract Scenario
     Add Module To Company  ${parent}[id]  sale_management
     Add Module To Company  ${parent}[id]  cash
     Add Module To Company  ${parent}[id]  scale
-    Add Module To User  ${parent_token}  ${PARENT_PHONE}  sale_management
-    Add Module To User  ${parent_token}  ${PARENT_PHONE}  cash
-    Add Module To User  ${parent_token}  ${PARENT_PHONE}  scale
+    Add Module To User  ${parent_token}  ${parent_phone}  sale_management
+    Add Module To User  ${parent_token}  ${parent_phone}  cash
+    Add Module To User  ${parent_token}  ${parent_phone}  scale
 
     Add Module To Company  ${member}[id]  stuff
-    Add Module To User  ${member_token}  ${MEMBER_PHONE}  stuff
+    Add Module To User  ${member_token}  ${member_phone}  stuff
 
     Add Module To Company  ${buyer}[id]  customer
-    Add Module To User  ${buyer_token}  ${BUYER_PHONE}  customer
+    Add Module To User  ${buyer_token}  ${buyer_phone}  customer
 
     ${new_stuff_req}  Create Dictionary  name=gc_member_stuff  comment=member_source  expect_count=${2}
     ${member_stuff}  Req to Server  /stuff/fetch  ${member_token}  ${new_stuff_req}
@@ -58,7 +67,7 @@ Setup Group Contract Scenario
 
     ${new_contract_req}  Create Dictionary  customer_id=${buyer}[id]
     Req to Server  /sale_management/contract_make  ${parent_token}  ${new_contract_req}
-    ${auth_req}  Create Dictionary  contract_id=${0}  phone=${BUYER_PHONE}
+    ${auth_req}  Create Dictionary  contract_id=${0}  phone=${buyer_phone}
     ${contract}  Req to Server  /sale_management/get_contract_by_customer  ${parent_token}  ${new_contract_req}
     Set To Dictionary  ${auth_req}  contract_id=${contract}[id]
     Req to Server  /sale_management/authorize_user  ${parent_token}  ${auth_req}

--- a/automation/group/group_contract_member_flow.robot
+++ b/automation/group/group_contract_member_flow.robot
@@ -1,0 +1,207 @@
+*** Settings ***
+Resource  ../api_base.resource
+Resource  ../database.resource
+Resource  ../rbac/rbac_curd.resource
+Resource  group.resource
+Library  DateTime
+Library  Collections
+
+Suite Setup       Group Contract Suite Reset
+Suite Teardown    Group Contract Suite Reset
+
+*** Variables ***
+${PARENT_PHONE}  16600000011
+${MEMBER_PHONE}  16600000012
+${BUYER_PHONE}  16600000013
+
+*** Keywords ***
+Group Contract Suite Reset
+    Group Tables Reset
+    Contract Reset
+    Plan Reset
+    Stuff Reset
+    RBAC reset
+    Company Reset
+
+Setup Group Contract Scenario
+    ${parent}  Create One Company  gc_parent
+    ${member}  Create One Company  gc_member
+    ${buyer}  Create One Company  gc_buyer
+
+    ${parent_token}  Login As Admin Of Company  ${parent}[id]  ${PARENT_PHONE}  gc_parent_admin
+    ${member_token}  Login As Admin Of Company  ${member}[id]  ${MEMBER_PHONE}  gc_member_admin
+    ${buyer_token}  Login As Admin Of Company  ${buyer}[id]  ${BUYER_PHONE}  gc_buyer_admin
+
+    ${parent_self}  Get Self Info  ${parent_token}
+    Convert To Group By Super Admin  ${parent}[id]  ${parent_self}[id]
+    ${add_member_req}  Create Dictionary  member_company_id=${member}[id]
+    Req to Server  /group/group_member_add  ${parent_token}  ${add_member_req}
+    Group Grant Upsert Self On Member  ${parent_token}  ${member}[id]  ${parent_self}[id]  ${True}  ${True}
+
+    Add Module To Company  ${parent}[id]  sale_management
+    Add Module To Company  ${parent}[id]  cash
+    Add Module To Company  ${parent}[id]  scale
+    Add Module To User  ${parent_token}  ${PARENT_PHONE}  sale_management
+    Add Module To User  ${parent_token}  ${PARENT_PHONE}  cash
+    Add Module To User  ${parent_token}  ${PARENT_PHONE}  scale
+
+    Add Module To Company  ${member}[id]  stuff
+    Add Module To User  ${member_token}  ${MEMBER_PHONE}  stuff
+
+    Add Module To Company  ${buyer}[id]  customer
+    Add Module To User  ${buyer_token}  ${BUYER_PHONE}  customer
+
+    ${new_stuff_req}  Create Dictionary  name=gc_member_stuff  comment=member_source  expect_count=${2}
+    ${member_stuff}  Req to Server  /stuff/fetch  ${member_token}  ${new_stuff_req}
+    ${price_req}  Create Dictionary  stuff_id=${member_stuff}[id]  price=${100}  to_plan=${False}  comment=group_test
+    Req to Server  /stuff/change_price  ${member_token}  ${price_req}
+
+    ${new_contract_req}  Create Dictionary  customer_id=${buyer}[id]
+    Req to Server  /sale_management/contract_make  ${parent_token}  ${new_contract_req}
+    ${auth_req}  Create Dictionary  contract_id=${0}  phone=${BUYER_PHONE}
+    ${contract}  Req to Server  /sale_management/get_contract_by_customer  ${parent_token}  ${new_contract_req}
+    Set To Dictionary  ${auth_req}  contract_id=${contract}[id]
+    Req to Server  /sale_management/authorize_user  ${parent_token}  ${auth_req}
+    ${contract_stuff_req}  Create Dictionary  contract_id=${contract}[id]  stuff_id=${member_stuff}[id]
+    Req to Server  /sale_management/contract_add_stuff  ${parent_token}  ${contract_stuff_req}
+
+    Set Suite Variable  ${PARENT_TOKEN}  ${parent_token}
+    Set Suite Variable  ${BUYER_TOKEN}  ${buyer_token}
+    Set Suite Variable  ${BUYER_COMPANY}  ${buyer}
+    Set Suite Variable  ${MEMBER_STUFF}  ${member_stuff}
+
+Find Stuff Id In List
+    [Arguments]  @{stuff_list}
+    ${hit}  Set Variable  ${False}
+    FOR  ${s}  IN  @{stuff_list}
+        IF  ${s}[id] == ${MEMBER_STUFF}[id]
+            ${hit}  Set Variable  ${True}
+            Exit For Loop
+        END
+    END
+    RETURN  ${hit}
+
+Get Sale Plan By Id
+    [Arguments]  ${plan_id}
+    ${today}  Get Current Date  result_format=%Y-%m-%d
+    ${req}  Create Dictionary  start_time=${today}  end_time=${today}
+    ${plans}  Req Get to Server  /customer/order_buy_search  ${BUYER_TOKEN}  plans  ${-1}  &{req}
+    ${target}  Set Variable  ${None}
+    FOR  ${p}  IN  @{plans}
+        IF  ${p}[id] == ${plan_id}
+            ${target}  Set Variable  ${p}
+            Exit For Loop
+        END
+    END
+    Should Not Be Equal  ${target}  ${None}
+    RETURN  ${target}
+
+*** Test Cases ***
+Group Contract Can Select Member Stuff
+    [Setup]  Setup Group Contract Scenario
+    ${opt_req}  Create Dictionary  pageNo=${0}
+    ${opt_resp}  Req to Server  /sale_management/get_stuff_for_contract  ${PARENT_TOKEN}  ${opt_req}
+    ${hit1}  Find Stuff Id In List  @{opt_resp}[stuff]
+    Should Be True  ${hit1}
+    ${on_sale_req}  Create Dictionary  pageNo=${0}
+    ${on_sale_resp}  Req to Server  /customer/get_stuff_on_sale  ${BUYER_TOKEN}  ${on_sale_req}
+    ${hit2}  Find Stuff Id In List  @{on_sale_resp}[stuff]
+    Should Be True  ${hit2}
+
+VerifyPayAndCloseUseGroupCustomerContract
+    [Setup]  Setup Group Contract Scenario
+    ${driver_req}  Create Dictionary  name=gc_driver  phone=16600000099
+    ${driver}  Req to Server  /customer/fetch_driver  ${BUYER_TOKEN}  ${driver_req}
+    ${main_req}  Create Dictionary  plate=京A12345
+    ${main_vehicle}  Req to Server  /customer/fetch_vehicle  ${BUYER_TOKEN}  ${main_req}
+    ${behind_req}  Create Dictionary  plate=京A54321
+    ${behind_vehicle}  Req to Server  /customer/fetch_vehicle  ${BUYER_TOKEN}  ${behind_req}
+    ${today}  Get Current Date  result_format=%Y-%m-%d
+    ${create_req}  Create Dictionary
+    ...  plan_time=${today}
+    ...  use_for=group-test
+    ...  drop_address=addr
+    ...  stuff_id=${MEMBER_STUFF}[id]
+    ...  main_vehicle_id=${main_vehicle}[id]
+    ...  behind_vehicle_id=${behind_vehicle}[id]
+    ...  driver_id=${driver}[id]
+    ${plan}  Req to Server  /customer/order_buy_create  ${BUYER_TOKEN}  ${create_req}
+
+    ${confirm_req}  Create Dictionary  plan_id=${plan}[id]
+    Req to Server  /sale_management/order_sale_confirm  ${PARENT_TOKEN}  ${confirm_req}
+    ${plan_after_confirm}  Get Sale Plan By Id  ${plan}[id]
+    Should Be Equal As Integers  ${plan_after_confirm}[status]  1
+
+    ${contract_req}  Create Dictionary  customer_id=${BUYER_COMPANY}[id]
+    ${contract_before}  Req to Server  /sale_management/get_contract_by_customer  ${PARENT_TOKEN}  ${contract_req}
+    ${charge_req}  Create Dictionary  contract_id=${contract_before}[id]  cash_increased=${400}  comment=group-balance
+    Req to Server  /cash/charge  ${PARENT_TOKEN}  ${charge_req}
+    Sleep  2s
+    ${plan_after_charge}  Get Sale Plan By Id  ${plan}[id]
+    Should Be Equal As Integers  ${plan_after_charge}[status]  2
+
+    ${deliver_req}  Create Dictionary
+    ...  plan_id=${plan}[id]
+    ...  p_weight=${10}
+    ...  m_weight=${20}
+    ...  count=${1}
+    ...  p_time=2026-01-01 10:00:00
+    ...  m_time=2026-01-01 10:10:00
+    Req to Server  /scale/deliver  ${PARENT_TOKEN}  ${deliver_req}
+    Sleep  1s
+
+    ${contract_after}  Req to Server  /sale_management/get_contract_by_customer  ${PARENT_TOKEN}  ${contract_req}
+    Should Be Equal As Numbers  ${contract_after}[balance]  300
+
+RollbackAfterCloseRestoresGroupCustomerContractBalance
+    [Setup]  Setup Group Contract Scenario
+    ${driver_req}  Create Dictionary  name=gc_driver_rb  phone=16600000098
+    ${driver}  Req to Server  /customer/fetch_driver  ${BUYER_TOKEN}  ${driver_req}
+    ${main_req}  Create Dictionary  plate=京A12346
+    ${main_vehicle}  Req to Server  /customer/fetch_vehicle  ${BUYER_TOKEN}  ${main_req}
+    ${behind_req}  Create Dictionary  plate=京A54322
+    ${behind_vehicle}  Req to Server  /customer/fetch_vehicle  ${BUYER_TOKEN}  ${behind_req}
+    ${today}  Get Current Date  result_format=%Y-%m-%d
+    ${create_req}  Create Dictionary
+    ...  plan_time=${today}
+    ...  use_for=group-test-rollback
+    ...  drop_address=addr
+    ...  stuff_id=${MEMBER_STUFF}[id]
+    ...  main_vehicle_id=${main_vehicle}[id]
+    ...  behind_vehicle_id=${behind_vehicle}[id]
+    ...  driver_id=${driver}[id]
+    ${plan}  Req to Server  /customer/order_buy_create  ${BUYER_TOKEN}  ${create_req}
+
+    ${confirm_req}  Create Dictionary  plan_id=${plan}[id]
+    Req to Server  /sale_management/order_sale_confirm  ${PARENT_TOKEN}  ${confirm_req}
+    ${plan_after_confirm}  Get Sale Plan By Id  ${plan}[id]
+    Should Be Equal As Integers  ${plan_after_confirm}[status]  1
+
+    ${contract_req}  Create Dictionary  customer_id=${BUYER_COMPANY}[id]
+    ${contract_before}  Req to Server  /sale_management/get_contract_by_customer  ${PARENT_TOKEN}  ${contract_req}
+    ${charge_req}  Create Dictionary  contract_id=${contract_before}[id]  cash_increased=${400}  comment=group-balance-rollback
+    Req to Server  /cash/charge  ${PARENT_TOKEN}  ${charge_req}
+    Sleep  2s
+    ${plan_after_charge}  Get Sale Plan By Id  ${plan}[id]
+    Should Be Equal As Integers  ${plan_after_charge}[status]  2
+
+    ${deliver_req}  Create Dictionary
+    ...  plan_id=${plan}[id]
+    ...  p_weight=${10}
+    ...  m_weight=${20}
+    ...  count=${1}
+    ...  p_time=2026-01-01 11:00:00
+    ...  m_time=2026-01-01 11:10:00
+    Req to Server  /scale/deliver  ${PARENT_TOKEN}  ${deliver_req}
+    Sleep  1s
+    ${contract_after_close}  Req to Server  /sale_management/get_contract_by_customer  ${PARENT_TOKEN}  ${contract_req}
+    Should Be Equal As Numbers  ${contract_after_close}[balance]  300
+
+    ${rollback_req}  Create Dictionary  plan_id=${plan}[id]  msg=rollback-after-close
+    Req to Server  /sale_management/order_rollback  ${PARENT_TOKEN}  ${rollback_req}
+    Sleep  1s
+    ${plan_after_rollback}  Get Sale Plan By Id  ${plan}[id]
+    Should Be Equal As Integers  ${plan_after_rollback}[status]  2
+    Should Be Equal As Numbers  ${plan_after_rollback}[count]  0
+    ${contract_after_rollback}  Req to Server  /sale_management/get_contract_by_customer  ${PARENT_TOKEN}  ${contract_req}
+    Should Be Equal As Numbers  ${contract_after_rollback}[balance]  400

--- a/automation/rbac/rbac_curd.resource
+++ b/automation/rbac/rbac_curd.resource
@@ -11,11 +11,12 @@ Search A Company By Name
     [Arguments]  ${name}
     @{cur_companys}  Get All Company
     ${found_content}  Create Dictionary
+    ${found_id}  Set Variable  ${-1}
     FOR  ${itr}  IN  @{cur_companys}
         ${itr_name}  Get From Dictionary  ${itr}  name
-        IF  $itr_name == $name
-        ${found_content}  Set Variable  ${itr}
-            Exit For Loop
+        IF  $itr_name == $name and ${itr}[id] > ${found_id}
+            ${found_content}  Set Variable  ${itr}
+            ${found_id}  Set Variable  ${itr}[id]
         END
     END
     RETURN  ${found_content}

--- a/automation/stuff/stuff_curd.robot
+++ b/automation/stuff/stuff_curd.robot
@@ -65,7 +65,8 @@ Stuff For Buy
 
 Stuff via Contract Maintain
     [Teardown]  Run Keywords  Contract Reset  AND  Stuff Reset
-    [Setup]  Run Keywords  Add A Company As Customer  ${buy_company1}[id]
+    [Setup]  Run Keywords  Set Buy Config Hard  ${True}
+    ...    AND  Add A Company As Customer  ${buy_company1}[id]
     ...    AND  Add A Company As Customer  ${buy_company2}[id]
     ...    AND  Add A Stuff to Sale  st1  abcdddd
     Add A Stuff To Contract  st1  bc1

--- a/automation/stuff/stuff_opt.resource
+++ b/automation/stuff/stuff_opt.resource
@@ -162,7 +162,7 @@ Add A Stuff To Contract
     Req to Server  /sale_management/contract_add_stuff  ${token}  ${req}
 
 Del A Stuff From Contract
-    [Arguments]  ${stuff_name}  ${customer_name}
+    [Arguments]  ${target_stuff_name}  ${customer_name}
     ${target_contract}  Set Variable
     ${target_stuff}  Set Variable
     ${found_contracts}  Req Get to Server  /sale_management/contract_get  ${sc_admin_token}  contracts
@@ -175,8 +175,8 @@ Del A Stuff From Contract
         END
     END
     FOR  ${itr}  IN  @{stuffs_found}
-        ${stuff_name}  Get From Dictionary  ${itr}  name
-        IF  $stuff_name == $stuff_name
+        ${got_stuff_name}  Get From Dictionary  ${itr}  name
+        IF  $got_stuff_name == $target_stuff_name
             ${target_stuff}  Set Variable  ${itr}
             Exit For Loop
         END
@@ -538,6 +538,11 @@ Set Pay Verify Role
     [Arguments]  ${is_cash}
     ${req}  Create Dictionary  verify_pay_by_cash=${is_cash}
     Req to Server  /stuff/set_verify_pay_config  ${sc_admin_token}  ${req}
+
+Set Buy Config Hard
+    [Arguments]  ${is_hard}=${True}  ${token}=${sc_admin_token}
+    ${req}  Create Dictionary  buy_config_hard=${is_hard}
+    Req to Server  /stuff/set_buy_config_hard  ${token}  ${req}
 
 Add Sct Scale Item
     [Arguments]  ${stuff_id}  ${item_name}  ${token}=${sc_admin_token}

--- a/mt_gui/src/subPage1/Contract.vue
+++ b/mt_gui/src/subPage1/Contract.vue
@@ -439,7 +439,11 @@ export default {
             if (this.$has_module('stuff') == false) {
                 return [];
             }
-            let resp = await this.$send_req('/stuff/get_all', {
+            let stuff_url = '/stuff/get_all';
+            if (this.cur_urls && this.cur_urls.motive && !buy_setting) {
+                stuff_url = '/sale_management/get_stuff_for_contract';
+            }
+            let resp = await this.$send_req(stuff_url, {
                 pageNo: pageNo
             });
             let ret = []

--- a/mt_gui/src/subPage1/Contract.vue
+++ b/mt_gui/src/subPage1/Contract.vue
@@ -436,11 +436,16 @@ export default {
             this.show_add_stuff = false;
         },
         get_stuff: async function (pageNo, [buy_setting]) {
-            if (this.$has_module('stuff') == false) {
+            const use_sale_management_stuff =
+                this.cur_urls && this.cur_urls.motive && !buy_setting;
+            const has_required_module = use_sale_management_stuff
+                ? this.$has_module('sale_management')
+                : this.$has_module('stuff');
+            if (has_required_module == false) {
                 return [];
             }
             let stuff_url = '/stuff/get_all';
-            if (this.cur_urls && this.cur_urls.motive && !buy_setting) {
+            if (use_sale_management_stuff) {
                 stuff_url = '/sale_management/get_stuff_for_contract';
             }
             let resp = await this.$send_req(stuff_url, {

--- a/mt_pc/src/components/ContractShowTable.vue
+++ b/mt_pc/src/components/ContractShowTable.vue
@@ -71,7 +71,7 @@
     <el-image-viewer v-if="show_pics" :on-close="close_preview" :url-list="pics">
     </el-image-viewer>
     <el-dialog title="新增物料" :visible.sync="show_add_stuff" width="30%">
-        <select-search body_key="stuff" get_url="/stuff/get_all" item_label="name" item_value="id" :permission_array="['stuff']" v-model="selected_stuff_id"></select-search>
+        <select-search body_key="stuff" :get_url="stuff_select_url" item_label="name" item_value="id" :permission_array="['stuff']" v-model="selected_stuff_id"></select-search>
         <span slot="footer">
             <el-button @click="show_add_stuff = false">取 消</el-button>
             <el-button type="primary" @click="do_add_stuff">确 定</el-button>
@@ -198,6 +198,12 @@ export default {
     computed: {
         charge_history_url() {
             return this.req_path === '/customer/contract_get' ? '/customer/history' : '/cash/history';
+        },
+        stuff_select_url() {
+            if (!this.is_buy && this.is_motive) {
+                return '/sale_management/get_stuff_for_contract';
+            }
+            return '/stuff/get_all';
         }
     },
     methods: {

--- a/mt_pc/src/components/ContractShowTable.vue
+++ b/mt_pc/src/components/ContractShowTable.vue
@@ -71,7 +71,7 @@
     <el-image-viewer v-if="show_pics" :on-close="close_preview" :url-list="pics">
     </el-image-viewer>
     <el-dialog title="新增物料" :visible.sync="show_add_stuff" width="30%">
-        <select-search body_key="stuff" :get_url="stuff_select_url" item_label="name" item_value="id" :permission_array="['stuff']" v-model="selected_stuff_id"></select-search>
+        <select-search body_key="stuff" :get_url="stuff_select_url" item_label="name" item_value="id" :permission_array="stuff_select_url === '/sale_management/get_stuff_for_contract' ? ['sale_management'] : ['stuff']" v-model="selected_stuff_id"></select-search>
         <span slot="footer">
             <el-button @click="show_add_stuff = false">取 消</el-button>
             <el-button type="primary" @click="do_add_stuff">确 定</el-button>


### PR DESCRIPTION
1.客户和工厂的合同不再使用，替换为集团和客户之间的合同
2.集团可以指定销售合同的货源是哪个成员公司的什么货物
3.客户主页看到的内容几乎不变
4.订单验款时要基于客户和集团之间的合同余额进行比较
5.订单关闭时要操作客户和集团之间的合同余额