### PR TITLE
ZYZL-676-集团特性-统计范围切换不显示的问题

### DIFF
--- a/api/lib/plan_lib.js
+++ b/api/lib/plan_lib.js
@@ -325,14 +325,13 @@ module.exports = {
     },
     get_all_sale_contracts: async function (_compnay, _pageNo, stuff_id) {
         let sq = db_opt.get_sq();
-        let owner_company = _compnay;
-        if (_compnay && _compnay.parentGroupCompanyId) {
-            let parent_company = await sq.models.company.findByPk(_compnay.parentGroupCompanyId);
-            if (parent_company) {
-                owner_company = parent_company;
-            }
+        if (!_compnay) {
+            return { rows: [], count: 0 };
         }
         let conditions = {
+            where: {
+                saleCompanyId: _compnay.id
+            },
             order: [['updatedAt', 'DESC'], ['id', 'DESC']],
             offset: _pageNo * 20,
             limit: 20,
@@ -347,8 +346,12 @@ module.exports = {
             conditions.include[1].where = { id: stuff_id };
             conditions.include[1].required = true;
         }
-        let rows = await owner_company.getSale_contracts(conditions);
-        let count = await owner_company.countSale_contracts();
+        let found_ret = await sq.models.contract.findAndCountAll({
+            ...conditions,
+            distinct: true,
+        });
+        let rows = found_ret.rows;
+        let count = found_ret.count;
         rows.forEach(item => {
             item.company = item.buy_company;
             item.expired = this.contractOutOfDate(item.end_time);

--- a/api/module/sale_management_module.js
+++ b/api/module/sale_management_module.js
@@ -18,6 +18,25 @@ function normalize_price(v) {
 async function resolve_contract_context_company(token, stat_context_company_id, need_write = false) {
     return await plan_lib.resolve_sale_contract_context_company(token, stat_context_company_id, need_write);
 }
+
+async function resolve_contract_stuff_operate_context(token, body) {
+    const company = await resolve_contract_context_company(token, body.stat_context_company_id, true);
+    const contract = await db_opt.get_sq().models.contract.findByPk(body.contract_id);
+    const stuff = await db_opt.get_sq().models.stuff.findByPk(body.stuff_id);
+    const stuff_company = stuff ? await stuff.getCompany() : null;
+    let can_use_stuff = false;
+    if (company && stuff_company) {
+        if (stuff_company.id === company.id) {
+            can_use_stuff = true;
+        } else if (company.is_group && stuff_company.parentGroupCompanyId === company.id) {
+            const user = await rbac_lib.get_user_by_token(token);
+            can_use_stuff = !!(user && await group_lib.user_has_member_data_access(user.id, stuff_company.id, true));
+        }
+    }
+    const can_operate = !!(contract && stuff && company && can_use_stuff
+        && await plan_lib.has_sale_contract_operate_permission(company, contract));
+    return { contract, stuff, can_operate };
+}
 module.exports = {
     name: 'sale_management',
     description: '销售管理',
@@ -439,25 +458,11 @@ module.exports = {
                 result: { type: Boolean, mean: '结果', example: true }
             },
             func: async function (body, token) {
-                let ret = { result: false };
-                let company = await resolve_contract_context_company(token, body.stat_context_company_id, true);
-                let contract = await db_opt.get_sq().models.contract.findByPk(body.contract_id);
-                let stuff = await db_opt.get_sq().models.stuff.findByPk(body.stuff_id);
-                let stuff_company = stuff ? await stuff.getCompany() : null;
-                let can_use_stuff = false;
-                if (company && stuff_company) {
-                    if (stuff_company.id === company.id) {
-                        can_use_stuff = true;
-                    } else if (company.is_group && stuff_company.parentGroupCompanyId === company.id) {
-                        const user = await rbac_lib.get_user_by_token(token);
-                        can_use_stuff = !!(user && await group_lib.user_has_member_data_access(user.id, stuff_company.id, true));
-                    }
-                }
-                if (contract && stuff && company && can_use_stuff && await plan_lib.has_sale_contract_operate_permission(company, contract)) {
+                const { contract, stuff, can_operate } = await resolve_contract_stuff_operate_context(token, body);
+                if (can_operate) {
                     await plan_lib.add_stuff_to_contract(stuff, contract);
-                    ret.result = true;
                 }
-                return ret;
+                return { result: can_operate };
             },
         },
         contract_del_stuff: {
@@ -475,25 +480,11 @@ module.exports = {
                 result: { type: Boolean, mean: '结果', example: true }
             },
             func: async function (body, token) {
-                let ret = { result: false };
-                let company = await resolve_contract_context_company(token, body.stat_context_company_id, true);
-                let contract = await db_opt.get_sq().models.contract.findByPk(body.contract_id);
-                let stuff = await db_opt.get_sq().models.stuff.findByPk(body.stuff_id);
-                let stuff_company = stuff ? await stuff.getCompany() : null;
-                let can_use_stuff = false;
-                if (company && stuff_company) {
-                    if (stuff_company.id === company.id) {
-                        can_use_stuff = true;
-                    } else if (company.is_group && stuff_company.parentGroupCompanyId === company.id) {
-                        const user = await rbac_lib.get_user_by_token(token);
-                        can_use_stuff = !!(user && await group_lib.user_has_member_data_access(user.id, stuff_company.id, true));
-                    }
-                }
-                if (contract && stuff && company && can_use_stuff && await plan_lib.has_sale_contract_operate_permission(company, contract)) {
+                const { contract, stuff, can_operate } = await resolve_contract_stuff_operate_context(token, body);
+                if (can_operate) {
                     await plan_lib.del_stuff_from_contract(stuff, contract);
-                    ret.result = true;
                 }
-                return ret;
+                return { result: can_operate };
             },
         },
         authorize_user: {

--- a/api/module/sale_management_module.js
+++ b/api/module/sale_management_module.js
@@ -320,10 +320,15 @@ module.exports = {
                 }
                 let company_ids = [company.id];
                 if (company.is_group) {
+                    const user = await rbac_lib.get_user_by_token(token);
                     const members = await company.getGroup_member_companies({ attributes: ['id'] });
-                    members.forEach((m) => {
-                        company_ids.push(m.id);
-                    });
+                    for (const m of members) {
+                        const has_member_access = user
+                            && await group_lib.user_has_member_data_access(user.id, m.id, false);
+                        if (has_member_access) {
+                            company_ids.push(m.id);
+                        }
+                    }
                 }
                 const ret = await sq.models.stuff.findAndCountAll({
                     where: {
@@ -439,10 +444,15 @@ module.exports = {
                 let contract = await db_opt.get_sq().models.contract.findByPk(body.contract_id);
                 let stuff = await db_opt.get_sq().models.stuff.findByPk(body.stuff_id);
                 let stuff_company = stuff ? await stuff.getCompany() : null;
-                let can_use_stuff = !!(company && stuff_company && (
-                    stuff_company.id === company.id ||
-                    (company.is_group && stuff_company.parentGroupCompanyId === company.id)
-                ));
+                let can_use_stuff = false;
+                if (company && stuff_company) {
+                    if (stuff_company.id === company.id) {
+                        can_use_stuff = true;
+                    } else if (company.is_group && stuff_company.parentGroupCompanyId === company.id) {
+                        const user = await rbac_lib.get_user_by_token(token);
+                        can_use_stuff = !!(user && await group_lib.user_has_member_data_access(user.id, stuff_company.id, true));
+                    }
+                }
                 if (contract && stuff && company && can_use_stuff && await plan_lib.has_sale_contract_operate_permission(company, contract)) {
                     await plan_lib.add_stuff_to_contract(stuff, contract);
                     ret.result = true;
@@ -470,10 +480,15 @@ module.exports = {
                 let contract = await db_opt.get_sq().models.contract.findByPk(body.contract_id);
                 let stuff = await db_opt.get_sq().models.stuff.findByPk(body.stuff_id);
                 let stuff_company = stuff ? await stuff.getCompany() : null;
-                let can_use_stuff = !!(company && stuff_company && (
-                    stuff_company.id === company.id ||
-                    (company.is_group && stuff_company.parentGroupCompanyId === company.id)
-                ));
+                let can_use_stuff = false;
+                if (company && stuff_company) {
+                    if (stuff_company.id === company.id) {
+                        can_use_stuff = true;
+                    } else if (company.is_group && stuff_company.parentGroupCompanyId === company.id) {
+                        const user = await rbac_lib.get_user_by_token(token);
+                        can_use_stuff = !!(user && await group_lib.user_has_member_data_access(user.id, stuff_company.id, true));
+                    }
+                }
                 if (contract && stuff && company && can_use_stuff && await plan_lib.has_sale_contract_operate_permission(company, contract)) {
                     await plan_lib.del_stuff_from_contract(stuff, contract);
                     ret.result = true;


### PR DESCRIPTION
问题定位过程为：
1.查看前端接口入参数，发现缺少
where: {
                saleCompanyId: _compnay.id
            },
之前测试账号之所以可以看到全部的是因为：
let owner_company = _compnay;
        if (_compnay && _compnay.parentGroupCompanyId) {
            let parent_company = await sq.models.company.findByPk(_compnay.parentGroupCompanyId);
            if (parent_company) {
                owner_company = parent_company;
            }
这样不管怎么样都可以查到测试公司的所有合同，所以看起来像是合同共享了导致判断错误。
2.删除成员公司，合同内还存在成员物料的bug。修复。。