### PR TITLE
ZYZL-677-集团的用户执行订单导出功能

### DIFF
--- a/api/lib/bidding_lib.js
+++ b/api/lib/bidding_lib.js
@@ -162,7 +162,10 @@ module.exports = {
                         { model: sq.models.stuff, include: [sq.models.company] }]
                 });
                 if (buy_company && bc && bc.stuff && bc.stuff.company) {
-                    let contracts = await plan_lib.get_sale_contracts_for_buyer_and_supply_company(buy_company.id, bc.stuff.company.id);
+                    let contracts = plan_lib.pick_sale_contracts_for_supply(
+                        await plan_lib.get_sale_contracts_for_buyer_and_supply_company(buy_company.id, bc.stuff.company.id),
+                        bc.stuff.company.id
+                    );
                     if (contracts.length == 1) {
                         let cur_balance = contracts[0].balance;
                         if (cur_balance >= bc.pay_first) {

--- a/api/lib/cash_lib.js
+++ b/api/lib/cash_lib.js
@@ -230,7 +230,11 @@ module.exports = {
                     }))[0];
                 }
                 else {
-                    contract = (await plan_lib.get_sale_contracts_for_buyer_and_supply_company(company.id, u8c_oi.company.id))[0];
+                    const contracts = plan_lib.pick_sale_contracts_for_supply(
+                        await plan_lib.get_sale_contracts_for_buyer_and_supply_company(company.id, u8c_oi.company.id),
+                        u8c_oi.company.id
+                    );
+                    contract = contracts[0];
                 }
             }
 

--- a/api/lib/group_lib.js
+++ b/api/lib/group_lib.js
@@ -208,6 +208,59 @@ module.exports = {
         }
     },
 
+    user_is_group_admin: function (user_id, group_company) {
+        return !!(group_company && group_company.is_group && group_company.group_admin_user_id === user_id);
+    },
+
+    user_has_any_member_operate_grant: async function (user_id, group_company_id) {
+        const sq = db_opt.get_sq();
+        const row = await sq.models.group_member_data_grant.findOne({
+            where: {
+                groupCompanyId: group_company_id,
+                rbacUserId: user_id,
+                can_operate: true,
+            },
+        });
+        return !!row;
+    },
+
+    /** 集团下选用/操作成员公司物料：任一成员有「可操作」授权则可操作全部成员；否则按单成员授权 */
+    user_can_use_group_member_stuff: async function (user_id, group_company, member_company_id, need_write) {
+        if (!group_company || !group_company.is_group) {
+            return false;
+        }
+        if (member_company_id === group_company.id) {
+            return true;
+        }
+        const sq = db_opt.get_sq();
+        const member_c = await sq.models.company.findByPk(member_company_id);
+        if (!member_c || member_c.parentGroupCompanyId !== group_company.id) {
+            return false;
+        }
+        if (this.user_is_group_admin(user_id, group_company)) {
+            return true;
+        }
+        if (await this.user_has_any_member_operate_grant(user_id, group_company.id)) {
+            return true;
+        }
+        return await this.user_has_member_data_access(user_id, member_company_id, need_write);
+    },
+
+    list_member_company_ids_for_stuff: async function (user_id, group_company) {
+        const members = await group_company.getGroup_member_companies({ attributes: ['id'] });
+        if (this.user_is_group_admin(user_id, group_company)
+            || await this.user_has_any_member_operate_grant(user_id, group_company.id)) {
+            return members.map((m) => m.id);
+        }
+        const ids = [];
+        for (const m of members) {
+            if (await this.user_has_member_data_access(user_id, m.id, false)) {
+                ids.push(m.id);
+            }
+        }
+        return ids;
+    },
+
     user_has_member_data_access: async function (user_id, member_company_id, need_write) {
         const sq = db_opt.get_sq();
         const user = await sq.models.rbac_user.findByPk(user_id);

--- a/api/lib/plan_lib.js
+++ b/api/lib/plan_lib.js
@@ -273,6 +273,17 @@ module.exports = {
         }
         return await sq.models.contract.findAll(query_opt);
     },
+    pick_sale_contracts_for_supply: function (contracts, supply_company_id) {
+        if (!contracts || contracts.length <= 1) {
+            return contracts || [];
+        }
+        const supply_id = Number(supply_company_id);
+        if (!Number.isFinite(supply_id)) {
+            return contracts;
+        }
+        const preferred = contracts.filter((c) => c.saleCompanyId === supply_id);
+        return preferred.length > 0 ? preferred : contracts;
+    },
     has_sale_contract_operate_permission: async function (company, contract) {
         if (!company || !contract) {
             return false;
@@ -975,7 +986,10 @@ module.exports = {
                 }
             }
 
-            let contracts = await this.get_sale_contracts_for_buyer_and_supply_company(company_id, plan.stuff.company.id);
+            let contracts = this.pick_sale_contracts_for_supply(
+                await this.get_sale_contracts_for_buyer_and_supply_company(company_id, plan.stuff.company.id),
+                plan.stuff.company.id
+            );
             let creator = await plan.getRbac_user();
             if (force || (creator && ((contracts.length == 1 && await contracts[0].hasRbac_user(creator)) || plan.is_buy))) {
                 plan.status = 1;
@@ -1173,7 +1187,10 @@ module.exports = {
         }, false, existing_t, allow_group_member_operate);
     },
     plan_cost: async function (plan) {
-        let contracts = await this.get_sale_contracts_for_buyer_and_supply_company(plan.company.id, plan.stuff.company.id);
+        let contracts = this.pick_sale_contracts_for_supply(
+            await this.get_sale_contracts_for_buyer_and_supply_company(plan.company.id, plan.stuff.company.id),
+            plan.stuff.company.id
+        );
         if (contracts.length == 1) {
             let contract = contracts[0];
             let decrease_cash = plan.unit_price * plan.count;
@@ -1200,7 +1217,10 @@ module.exports = {
         }
     },
     plan_undo_cost: async function (plan) {
-        let contracts = await this.get_sale_contracts_for_buyer_and_supply_company(plan.company.id, plan.stuff.company.id);
+        let contracts = this.pick_sale_contracts_for_supply(
+            await this.get_sale_contracts_for_buyer_and_supply_company(plan.company.id, plan.stuff.company.id),
+            plan.stuff.company.id
+        );
         if (contracts.length == 1) {
             let contract = contracts[0];
             let decrease_cash = plan.unit_price * plan.count;
@@ -1547,11 +1567,14 @@ module.exports = {
             return { arrears: 0, outstanding_vehicles: 0 };
         }
         const price_to_use = unit_price !== null ? unit_price : plan.unit_price;
-        let contracts = await this.get_sale_contracts_for_buyer_and_supply_company(
-            plan.company.id,
-            plan.stuff.company.id,
-            false,
-            transaction
+        let contracts = this.pick_sale_contracts_for_supply(
+            await this.get_sale_contracts_for_buyer_and_supply_company(
+                plan.company.id,
+                plan.stuff.company.id,
+                false,
+                transaction
+            ),
+            plan.stuff.company.id
         );
         let cur_balance = 0;
         if (contracts.length == 1) {

--- a/api/lib/plan_lib.js
+++ b/api/lib/plan_lib.js
@@ -2118,7 +2118,9 @@ module.exports = {
             totalPriceSum += totalPriceVal;
             json.push({
                 create_company: this.place_hold(element.company, { name: '(司机选择)' }).name,
-                accept_company: element.stuff.company.name,
+                accept_company: include_supply_company
+                    ? (home_company.name || element.stuff?.company?.name || '')
+                    : element.stuff.company.name,
                 stuff_name: element.stuff.name,
                 plan_time: element.plan_time,
                 ticket_no: element.ticket_no,

--- a/api/lib/plan_lib.js
+++ b/api/lib/plan_lib.js
@@ -162,7 +162,7 @@ module.exports = {
                         SELECT 1 FROM contract c
                         WHERE c.deletedAt IS NULL
                           AND c.buyCompanyId = ${_buy_company.id}
-                          AND c.saleCompanyId = ${sale_owner_company_sql}
+                          AND c.saleCompanyId IN (${sale_owner_company_sql}, stuff.companyId)
                           AND EXISTS (
                               SELECT 1 FROM contract_stuff cs
                               WHERE cs.stuffId = stuff.id AND cs.contractId = c.id
@@ -248,12 +248,22 @@ module.exports = {
     get_sale_contracts_for_buyer_and_supply_company: async function (buy_company_id, supply_company_id, include_users = false, transaction = null) {
         const sq = db_opt.get_sq();
         const owner_company_id = await this.get_sale_contract_owner_company_id(supply_company_id, transaction);
-        if (!owner_company_id) {
+        const sale_company_ids = [];
+        if (owner_company_id) {
+            sale_company_ids.push(owner_company_id);
+        }
+        const supply_id = Number(supply_company_id);
+        if (Number.isFinite(supply_id) && supply_id > 0 && !sale_company_ids.includes(supply_id)) {
+            sale_company_ids.push(supply_id);
+        }
+        if (sale_company_ids.length === 0) {
             return [];
         }
         const query_opt = {
             where: {
-                saleCompanyId: owner_company_id,
+                saleCompanyId: sale_company_ids.length === 1
+                    ? sale_company_ids[0]
+                    : { [db_opt.Op.in]: sale_company_ids },
                 buyCompanyId: buy_company_id
             },
             ...(transaction && { transaction })
@@ -269,6 +279,13 @@ module.exports = {
         }
         if (await company.hasSale_contract(contract)) {
             return true;
+        }
+        if (company.is_group && contract.saleCompanyId && contract.saleCompanyId !== company.id) {
+            const sq = db_opt.get_sq();
+            const sale_company = await sq.models.company.findByPk(contract.saleCompanyId);
+            if (sale_company && sale_company.parentGroupCompanyId === company.id) {
+                return true;
+            }
         }
         if (company.parentGroupCompanyId) {
             const sq = db_opt.get_sq();
@@ -1991,20 +2008,45 @@ module.exports = {
             [db_opt.Op.and]: this.buildTimeCondition(body, sq),
         };
         let order = this.default_export_sort(sq);
-        if (body.stuff_id) {
-            cond.stuffId = body.stuff_id
-        }
-        else {
-            let company = await rbac_lib.get_company_by_token(token);
-            let stuff = await company.getStuff();
-            let stuff_array = [];
-            for (let index = 0; index < stuff.length; index++) {
-                const element = stuff[index];
-                stuff_array.push(element.id);
+        const home_company = await rbac_lib.get_company_by_token(token);
+        if (!home_company || !home_company.is_group) {
+            if (body.stuff_id) {
+                cond.stuffId = body.stuff_id;
+            } else {
+                let stuff = await home_company.getStuff();
+                let stuff_array = [];
+                for (let index = 0; index < stuff.length; index++) {
+                    stuff_array.push(stuff[index].id);
+                }
+                cond.stuffId = {
+                    [db_opt.Op.or]: stuff_array,
+                };
             }
-            cond.stuffId = {
-                [db_opt.Op.or]: stuff_array
+        } else {
+            const user = await rbac_lib.get_user_by_token(token);
+            let allowed_company_ids = [home_company.id];
+            if (user) {
+                const member_ids = await group_lib.list_member_company_ids_for_stuff(user.id, home_company);
+                allowed_company_ids.push(...member_ids);
             }
+            allowed_company_ids = [...new Set(allowed_company_ids)];
+            let stuff_ids = [];
+            if (body.stuff_id) {
+                const stuff = await sq.models.stuff.findByPk(body.stuff_id, { attributes: ['id', 'companyId'] });
+                if (stuff && allowed_company_ids.includes(stuff.companyId)) {
+                    stuff_ids = [stuff.id];
+                }
+            } else if (allowed_company_ids.length > 0) {
+                const stuff_rows = await sq.models.stuff.findAll({
+                    where: { companyId: { [db_opt.Op.in]: allowed_company_ids } },
+                    attributes: ['id'],
+                });
+                stuff_ids = stuff_rows.map((s) => s.id);
+            }
+            if (stuff_ids.length === 0) {
+                return [];
+            }
+            cond.stuffId = stuff_ids.length === 1 ? stuff_ids[0] : { [db_opt.Op.in]: stuff_ids };
         }
         if (body.company_id) {
             cond.companyId = body.company_id
@@ -2030,7 +2072,9 @@ module.exports = {
             return input
         }
     },
-    make_file_by_plans: async function (plans, columns_defined) {
+    make_file_by_plans: async function (plans, columns_defined, token) {
+        const home_company = token ? await rbac_lib.get_company_by_token(token) : null;
+        const include_supply_company = !!(home_company && home_company.is_group);
         let json = [];
         let unifiedDecimalPlaces = 2;
         let totalOrders = 0;
@@ -2087,6 +2131,7 @@ module.exports = {
                 })(),
                 plan_counts: countVal,
                 total_orders: totalOrders,
+                ...(include_supply_company ? { supply_company: element.stuff?.company?.name || '' } : {}),
             });
         }
         let columns = [{
@@ -2174,10 +2219,20 @@ module.exports = {
             header: '金蝶星辰同步信息',
             key: 'king_dee_comment'
         }];
+        if (include_supply_company) {
+            columns.splice(2, 0, {
+                header: '货源公司',
+                key: 'supply_company',
+            });
+        }
         let workbook = new ExcelJS.Workbook();
         let worksheet = workbook.addWorksheet('Plans');
         if (columns_defined) {
-            worksheet.columns = columns_defined.map((item) => {
+            let cols = columns_defined;
+            if (!include_supply_company) {
+                cols = cols.filter((item) => item.name !== 'supply_company');
+            }
+            worksheet.columns = cols.map((item) => {
                 return {
                     header: item.label,
                     key: item.name,

--- a/api/module/buy_management_module.js
+++ b/api/module/buy_management_module.js
@@ -69,10 +69,13 @@ module.exports = {
             result: common.contract_res_detail_define,
             func: async function (body, token) {
                 let company = await rbac_lib.get_company_by_token(token);
-                let contracts = await plan_lib.get_sale_contracts_for_buyer_and_supply_company(
-                    company.id,
-                    body.supplier_id,
-                    true
+                let contracts = plan_lib.pick_sale_contracts_for_supply(
+                    await plan_lib.get_sale_contracts_for_buyer_and_supply_company(
+                        company.id,
+                        body.supplier_id,
+                        true
+                    ),
+                    body.supplier_id
                 );
                 if (contracts.length != 1) {
                     throw { err_msg: "合同不存在" }

--- a/api/module/buy_management_module.js
+++ b/api/module/buy_management_module.js
@@ -69,12 +69,11 @@ module.exports = {
             result: common.contract_res_detail_define,
             func: async function (body, token) {
                 let company = await rbac_lib.get_company_by_token(token);
-                let contracts = await company.getBuy_contracts({
-                    where: {
-                        saleCompanyId: body.supplier_id
-                    },
-                    include: db_opt.get_sq().models.rbac_user
-                })
+                let contracts = await plan_lib.get_sale_contracts_for_buyer_and_supply_company(
+                    company.id,
+                    body.supplier_id,
+                    true
+                );
                 if (contracts.length != 1) {
                     throw { err_msg: "合同不存在" }
                 }
@@ -336,7 +335,7 @@ module.exports = {
         },
         export_plans: common.export_plans(async function (body, token) {
             let plans = await plan_lib.filter_plan4manager(body, token, true);
-            return await plan_lib.make_file_by_plans(plans, body.columns);
+            return await plan_lib.make_file_by_plans(plans, body.columns, token);
         }),
     }
 }

--- a/api/module/customer_module.js
+++ b/api/module/customer_module.js
@@ -399,7 +399,7 @@ module.exports = {
         },
         export_plans: common.export_plans(async function (body, token) {
             let plans = await plan_lib.filter_plan4user(body, token, false);
-            return await plan_lib.make_file_by_plans(plans, body.columns);
+            return await plan_lib.make_file_by_plans(plans, body.columns, token);
         }),
         checkout_plan: {
             name: '结算',

--- a/api/module/customer_module.js
+++ b/api/module/customer_module.js
@@ -229,7 +229,10 @@ module.exports = {
                     await new_plan.setRbac_user(user);
                     await plan_lib.rp_history_create(new_plan, user.name);
                     new_plan.unit_price = stuff.price;
-                    let contracts = await plan_lib.get_sale_contracts_for_buyer_and_supply_company(buy_company.id, sale_company.id);
+                    let contracts = plan_lib.pick_sale_contracts_for_supply(
+                        await plan_lib.get_sale_contracts_for_buyer_and_supply_company(buy_company.id, sale_company.id),
+                        sale_company.id
+                    );
                     if (contracts.length === 1) {
                         new_plan.unit_price = await plan_lib.get_contract_effective_unit_price(contracts[0], stuff, new_plan.unit_price);
                     }

--- a/api/module/sale_management_module.js
+++ b/api/module/sale_management_module.js
@@ -20,21 +20,24 @@ async function resolve_contract_context_company(token, stat_context_company_id, 
 }
 
 async function resolve_contract_stuff_operate_context(token, body) {
+    const home_company = await rbac_lib.get_company_by_token(token);
     const company = await resolve_contract_context_company(token, body.stat_context_company_id, true);
+    const group_company = home_company && home_company.is_group ? home_company : company;
     const contract = await db_opt.get_sq().models.contract.findByPk(body.contract_id);
     const stuff = await db_opt.get_sq().models.stuff.findByPk(body.stuff_id);
     const stuff_company = stuff ? await stuff.getCompany() : null;
     let can_use_stuff = false;
-    if (company && stuff_company) {
-        if (stuff_company.id === company.id) {
+    if (group_company && stuff_company) {
+        if (stuff_company.id === company.id || stuff_company.id === group_company.id) {
             can_use_stuff = true;
-        } else if (company.is_group && stuff_company.parentGroupCompanyId === company.id) {
+        } else if (group_company.is_group && stuff_company.parentGroupCompanyId === group_company.id) {
             const user = await rbac_lib.get_user_by_token(token);
-            can_use_stuff = !!(user && await group_lib.user_has_member_data_access(user.id, stuff_company.id, true));
+            can_use_stuff = !!(user && await group_lib.user_can_use_group_member_stuff(user.id, group_company, stuff_company.id, true));
         }
     }
-    const can_operate = !!(contract && stuff && company && can_use_stuff
-        && await plan_lib.has_sale_contract_operate_permission(company, contract));
+    const permission_company = group_company || company;
+    const can_operate = !!(contract && stuff && permission_company && can_use_stuff
+        && await plan_lib.has_sale_contract_operate_permission(permission_company, contract));
     return { contract, stuff, can_operate };
 }
 module.exports = {
@@ -296,15 +299,43 @@ module.exports = {
             is_get_api: false,
             params: {
                 customer_id: { type: Number, have_to: true, mean: '客户ID', example: 1 },
+                supply_company_id: { type: Number, have_to: false, mean: '供货/卖方公司ID（订单物料归属公司）', example: 1 },
                 stat_context_company_id: { type: Number, have_to: false, mean: '集团场景操作主体公司id', example: 1 },
             },
             result: common.contract_res_detail_define,
             func: async function (body, token) {
+                const sq = db_opt.get_sq();
                 let company = await resolve_contract_context_company(token, body.stat_context_company_id, false);
                 if (!company) {
                     throw { err_msg: '无权限' };
                 }
-                let contracts = await plan_lib.get_sale_contracts_for_buyer_and_supply_company(body.customer_id, company.id, true);
+                let supply_company_id = company.id;
+                if (body.supply_company_id !== undefined && body.supply_company_id !== null && body.supply_company_id !== '') {
+                    const supply_id = Number(body.supply_company_id);
+                    if (Number.isFinite(supply_id)) {
+                        if (supply_id !== company.id) {
+                            const supply_company = await sq.models.company.findByPk(supply_id);
+                            const home_company = await rbac_lib.get_company_by_token(token);
+                            const user = await rbac_lib.get_user_by_token(token);
+                            if (!supply_company || !home_company || !home_company.is_group || !user
+                                || !(await group_lib.user_can_use_group_member_stuff(user.id, home_company, supply_id, false))) {
+                                throw { err_msg: '无权限' };
+                            }
+                        }
+                        supply_company_id = supply_id;
+                    }
+                }
+                let contracts = await plan_lib.get_sale_contracts_for_buyer_and_supply_company(
+                    body.customer_id,
+                    supply_company_id,
+                    true
+                );
+                if (contracts.length > 1) {
+                    const preferred = contracts.filter((item) => item.saleCompanyId === supply_company_id);
+                    if (preferred.length === 1) {
+                        contracts = preferred;
+                    }
+                }
                 if (contracts.length != 1) {
                     throw { err_msg: "合同不存在" }
                 }
@@ -333,22 +364,21 @@ module.exports = {
             },
             func: async function (body, token) {
                 const sq = db_opt.get_sq();
-                const company = await resolve_contract_context_company(token, body.stat_context_company_id, false);
-                if (!company) {
+                const home_company = await rbac_lib.get_company_by_token(token);
+                const context_company = await resolve_contract_context_company(token, body.stat_context_company_id, false);
+                if (!context_company || !home_company) {
                     return { stuff: [], total: 0 };
                 }
-                let company_ids = [company.id];
-                if (company.is_group) {
+                const group_company = home_company.is_group ? home_company : context_company;
+                let company_ids = [group_company.id];
+                if (group_company.is_group) {
                     const user = await rbac_lib.get_user_by_token(token);
-                    const members = await company.getGroup_member_companies({ attributes: ['id'] });
-                    for (const m of members) {
-                        const has_member_access = user
-                            && await group_lib.user_has_member_data_access(user.id, m.id, false);
-                        if (has_member_access) {
-                            company_ids.push(m.id);
-                        }
+                    if (user) {
+                        const member_ids = await group_lib.list_member_company_ids_for_stuff(user.id, group_company);
+                        company_ids.push(...member_ids);
                     }
                 }
+                company_ids = [...new Set(company_ids)];
                 const ret = await sq.models.stuff.findAndCountAll({
                     where: {
                         use_for_buy: false,
@@ -362,7 +392,7 @@ module.exports = {
                     limit: 20,
                 });
                 ret.rows.forEach((item) => {
-                    if (item.companyId !== company.id) {
+                    if (group_company.is_group && item.companyId !== group_company.id && item.company) {
                         item.name = `${item.company.name}-${item.name}`;
                     }
                 });
@@ -676,7 +706,7 @@ module.exports = {
                 if (company.is_group && stuff.companyId !== company.id) {
                     const user = await rbac_lib.get_user_by_token(token);
                     const has_member_operate_permission = user
-                        && await group_lib.user_has_member_data_access(user.id, stuff.companyId, true);
+                        && await group_lib.user_can_use_group_member_stuff(user.id, company, stuff.companyId, true);
                     if (!has_member_operate_permission) {
                         const err = new Error('无权限');
                         err.err_msg = '无权限';
@@ -706,7 +736,7 @@ module.exports = {
         },
         export_plans: common.export_plans(async function (body, token) {
             let plans = await plan_lib.filter_plan4manager(body, token);
-            return await plan_lib.make_file_by_plans(plans, body.columns);
+            return await plan_lib.make_file_by_plans(plans, body.columns, token);
         }),
         export_exe_rate: {
             name: '导出执行率',

--- a/api/module/sale_management_module.js
+++ b/api/module/sale_management_module.js
@@ -691,8 +691,9 @@ module.exports = {
                 result: { type: Boolean, mean: '结果', example: true }
             },
             func: async function (body, token) {
+                const sq = db_opt.get_sq();
                 const home_company = await rbac_lib.get_company_by_token(token);
-                const stuff_preview = await db_opt.get_sq().models.stuff.findByPk(body.stuff_id);
+                const stuff_preview = await sq.models.stuff.findByPk(body.stuff_id);
                 const stuff_company = stuff_preview ? await stuff_preview.getCompany() : null;
                 if (home_company && home_company.is_group && stuff_company
                     && stuff_company.parentGroupCompanyId === home_company.id

--- a/api/module/sale_management_module.js
+++ b/api/module/sale_management_module.js
@@ -330,12 +330,7 @@ module.exports = {
                     supply_company_id,
                     true
                 );
-                if (contracts.length > 1) {
-                    const preferred = contracts.filter((item) => item.saleCompanyId === supply_company_id);
-                    if (preferred.length === 1) {
-                        contracts = preferred;
-                    }
-                }
+                contracts = plan_lib.pick_sale_contracts_for_supply(contracts, supply_company_id);
                 if (contracts.length != 1) {
                     throw { err_msg: "合同不存在" }
                 }
@@ -696,22 +691,20 @@ module.exports = {
                 result: { type: Boolean, mean: '结果', example: true }
             },
             func: async function (body, token) {
-                const sq = db_opt.get_sq();
-                const company = await resolve_contract_context_company(token, body.stat_context_company_id, true);
-                const contract = await sq.models.contract.findByPk(body.contract_id);
-                const stuff = await sq.models.stuff.findByPk(body.stuff_id);
-                if (!contract || !stuff || !(await plan_lib.has_sale_contract_operate_permission(company, contract))) {
+                const home_company = await rbac_lib.get_company_by_token(token);
+                const stuff_preview = await db_opt.get_sq().models.stuff.findByPk(body.stuff_id);
+                const stuff_company = stuff_preview ? await stuff_preview.getCompany() : null;
+                if (home_company && home_company.is_group && stuff_company
+                    && stuff_company.parentGroupCompanyId === home_company.id
+                    && stuff_company.id !== home_company.id
+                    && (body.stat_context_company_id === undefined
+                        || body.stat_context_company_id === null
+                        || body.stat_context_company_id === '')) {
                     throw { err_msg: '无权限' };
                 }
-                if (company.is_group && stuff.companyId !== company.id) {
-                    const user = await rbac_lib.get_user_by_token(token);
-                    const has_member_operate_permission = user
-                        && await group_lib.user_can_use_group_member_stuff(user.id, company, stuff.companyId, true);
-                    if (!has_member_operate_permission) {
-                        const err = new Error('无权限');
-                        err.err_msg = '无权限';
-                        throw err;
-                    }
+                const { contract, stuff, can_operate } = await resolve_contract_stuff_operate_context(token, body);
+                if (!can_operate || !contract || !stuff) {
+                    throw { err_msg: '无权限' };
                 }
                 if (!(await contract.hasStuff(stuff))) {
                     throw { err_msg: '该合同未关联此物料' };

--- a/api/module/supplier_module.js
+++ b/api/module/supplier_module.js
@@ -284,7 +284,7 @@ module.exports = {
 
         export_plans: common.export_plans(async function (body, token) {
             let plans = await plan_lib.filter_plan4user(body, token, true);
-            return await plan_lib.make_file_by_plans(plans, body.columns);
+            return await plan_lib.make_file_by_plans(plans, body.columns, token);
         }),
     }
 }

--- a/mt_gui/src/pages/OrderList.vue
+++ b/mt_gui/src/pages/OrderList.vue
@@ -1394,9 +1394,14 @@ export default {
             if ((this.$has_module('sale_management') || this.$has_module('buy_management')) && item.company.id) {
                 try {
                     let url = this.cur_is_buy ? '/buy_management/get_contract_by_supplier' : '/sale_management/get_contract_by_customer';
-                    let resp = await this.$send_req(url, make_context_req({
-                        [this.cur_is_buy ? 'supplier_id' : 'customer_id']: item.company.id,
-                    }, url, ssss_bool, scci))
+                    let contract_req = {};
+                    if (this.cur_is_buy) {
+                        contract_req.supplier_id = item.stuff.company.id;
+                    } else {
+                        contract_req.customer_id = item.company.id;
+                        contract_req.supply_company_id = item.stuff.company.id;
+                    }
+                    let resp = await this.$send_req(url, make_context_req(contract_req, url, ssss_bool, scci))
                     // 标注合同是否一个月内即将到期
                     const oneMonthFromNow = moment().add(1, 'month');
                     const contractEndDate = moment(resp.end_time);

--- a/mt_pc/src/components/OrderDetail.vue
+++ b/mt_pc/src/components/OrderDetail.vue
@@ -303,10 +303,15 @@ export default {
     props: {
         plan: Object,
         motived: Boolean,
+        stat_context_company_id: {
+            type: Number,
+            default: null,
+        },
     },
     watch: {
         'plan.id': function () {
             this.refresh_approval_projects();
+            this.init_contract();
         },
     },
     methods: {
@@ -652,9 +657,17 @@ export default {
             if ((this.$hasPermission('sale_management') || this.$hasPermission('buy_management')) && this.plan.company.id) {
                 try {
                     let url = this.plan.is_buy ? '/buy_management/get_contract_by_supplier' : '/sale_management/get_contract_by_customer';
-                    let resp = await this.$send_req(url, {
-                        [this.plan.is_buy ? 'supplier_id' : 'customer_id']: this.plan.company.id,
-                    })
+                    let req = {};
+                    if (this.plan.is_buy) {
+                        req.supplier_id = this.plan.stuff.company.id;
+                    } else {
+                        req.customer_id = this.plan.company.id;
+                        req.supply_company_id = this.plan.stuff.company.id;
+                    }
+                    if (this.stat_context_company_id != null) {
+                        req.stat_context_company_id = this.stat_context_company_id;
+                    }
+                    let resp = await this.$send_req(url, req);
                     // 标注合同是否一个月内即将到期
                     const oneMonthFromNow = moment().add(1, 'month');
                     const contractEndDate = moment(resp.end_time);

--- a/mt_pc/src/components/OrderShowTable.vue
+++ b/mt_pc/src/components/OrderShowTable.vue
@@ -130,7 +130,7 @@
         </template>
     </page-content>
     <el-drawer destroy-on-close title="计划详情" :visible.sync="show_plan_detail" direction="rtl" size="70%">
-        <order-detail :motived="motived" :plan="focus_plan" @refresh="show_plan_detail= false; refresh_order()"></order-detail>
+        <order-detail :motived="motived" :plan="focus_plan" :stat_context_company_id="stat_context_company_id" @refresh="show_plan_detail= false; refresh_order()"></order-detail>
     </el-drawer>
     <el-dialog append-to-body title="设置代理" :visible.sync="delegate_show" width="30%">
         <select-search body_key="delegates" get_url="/stuff/get_delegates" item_label="name" item_value="id" :permission_array="['sale_management', 'buy_management']" v-model="delegate_id"></select-search>

--- a/mt_pc/src/views/dashboard.vue
+++ b/mt_pc/src/views/dashboard.vue
@@ -107,7 +107,7 @@
                                 </el-table-column>
                                 <el-table-column label="操作">
                                     <template slot-scope="scope">
-                                        <el-button v-if="price != -1" size="mini" type="primary" @click="start_plan_creation(scope.row, true)" min-width="40">下单</el-button>
+                                        <el-button v-if="scope.row.price != -1" size="mini" type="primary" @click="start_plan_creation(scope.row, true)" min-width="40">下单</el-button>
                                     </template>
                                 </el-table-column>
                             </el-table>

--- a/mt_pc/src/views/export/ExportExecute.vue
+++ b/mt_pc/src/views/export/ExportExecute.vue
@@ -2,7 +2,7 @@
 <div class="export_execute_show">
     <div class="export_execute_header">
         <h2>订单明细导出</h2>
-        <array-selector-button v-model="columns_defined" @change="save_cd_local"></array-selector-button>
+        <array-selector-button v-model="columns_defined" :options="export_column_options" @change="save_cd_local"></array-selector-button>
     </div>
     <vue-grid align="stretch">
         <vue-cell class="cell_show" v-for="(single_module, index) in all_module" :key="index" width="3of12">
@@ -52,6 +52,102 @@ import {
     VueCell
 } from 'vue-grd';
 import ArraySelectorButton from '../../components/ArraySelectorButton.vue';
+
+const BASE_EXPORT_COLUMNS = [{
+    label: '下单公司',
+    name: 'create_company',
+}, {
+    label: '接单公司',
+    name: 'accept_company',
+}, {
+    label: '计划时间',
+    name: 'plan_time',
+}, {
+    label: '过皮时间',
+    name: 'p_time',
+}, {
+    label: '过毛时间',
+    name: 'm_time',
+}, {
+    label: '主车号',
+    name: 'mv',
+}, {
+    label: '挂车号',
+    name: 'bv',
+}, {
+    label: '司机姓名',
+    name: 'driver_name',
+}, {
+    label: '司机电话',
+    name: 'driver_phone',
+}, {
+    label: '皮重',
+    name: 'p_weight',
+}, {
+    label: '毛重',
+    name: 'm_weight',
+}, {
+    label: '装车量',
+    name: 'count',
+}, {
+    label: '单价',
+    name: 'unit_price',
+}, {
+    label: '总价',
+    name: 'total_price',
+}, {
+    label: '铅封号',
+    name: 'seal_no',
+}, {
+    label: '磅单号',
+    name: 'ticket_no',
+}, {
+    label: '物料名',
+    name: 'stuff_name',
+}, {
+    label: '卸货地址',
+    name: 'drop_address',
+}, {
+    label: '发票已开?',
+    name: 'fapiao_delivered',
+}, {
+    label: '备注',
+    name: 'comment',
+}, {
+    label: '装卸区域',
+    name: 'drop_take_zone_name',
+}, {
+    label: '代理公司',
+    name: 'delegate',
+}, {
+    label: '打折后单价',
+    name: 'subsidy_price',
+}, {
+    label: '打折后总价',
+    name: 'subsidy_total_price',
+}, {
+    label: '打折数',
+    name: 'subsidy_discount',
+}, {
+    label: '第二单位',
+    name: 'second_unit',
+}, {
+    label: '第二单位装卸量',
+    name: 'second_value',
+}, {
+    label: '金蝶星辰同步信息',
+    name: 'king_dee_comment',
+}];
+
+const SUPPLY_EXPORT_COLUMN = { label: '货源公司', name: 'supply_company' };
+
+function insert_supply_column(columns) {
+    const cols = columns.filter((c) => c.name !== 'supply_company');
+    const accept_idx = cols.findIndex((c) => c.name === 'accept_company');
+    cols.splice(accept_idx >= 0 ? accept_idx + 1 : 2, 0, SUPPLY_EXPORT_COLUMN);
+    return cols;
+}
+
 export default {
     name: 'ExportExecute',
     components: {
@@ -62,91 +158,8 @@ export default {
     },
     data: function () {
         return {
-            columns_defined: [{
-                label: '下单公司',
-                name: 'create_company',
-            }, {
-                label: '接单公司',
-                name: 'accept_company',
-            }, {
-                label: '计划时间',
-                name: 'plan_time',
-            }, {
-                label: '过皮时间',
-                name: 'p_time',
-            }, {
-                label: '过毛时间',
-                name: 'm_time',
-            }, {
-                label: '主车号',
-                name: 'mv',
-            }, {
-                label: '挂车号',
-                name: 'bv',
-            }, {
-                label: '司机姓名',
-                name: 'driver_name',
-            }, {
-                label: '司机电话',
-                name: 'driver_phone',
-            }, {
-                label: '皮重',
-                name: 'p_weight',
-            }, {
-                label: '毛重',
-                name: 'm_weight',
-            }, {
-                label: '装车量',
-                name: 'count',
-            }, {
-                label: '单价',
-                name: 'unit_price',
-            }, {
-                label: '总价',
-                name: 'total_price',
-            }, {
-                label: '铅封号',
-                name: 'seal_no',
-            }, {
-                label: '磅单号',
-                name: 'ticket_no',
-            }, {
-                label: '物料名',
-                name: 'stuff_name',
-            }, {
-                label: '卸货地址',
-                name: 'drop_address',
-            }, {
-                label: '发票已开?',
-                name: 'fapiao_delivered',
-            }, {
-                label: '备注',
-                name: 'comment',
-            }, {
-                label: '装卸区域',
-                name: 'drop_take_zone_name'
-            }, {
-                label: '代理公司',
-                name: 'delegate'
-            }, {
-                label: '打折后单价',
-                name: 'subsidy_price'
-            }, {
-                label: '打折后总价',
-                name: 'subsidy_total_price'
-            }, {
-                label: '打折数',
-                name: 'subsidy_discount'
-            }, {
-                label: '第二单位',
-                name: 'second_unit'
-            }, {
-                label: '第二单位装卸量',
-                name: 'second_value'
-            }, {
-                label: '金蝶星辰同步信息',
-                name: 'king_dee_comment'
-            }],
+            columns_defined: [...BASE_EXPORT_COLUMNS],
+            company_is_group: false,
             orig_all_module: [{
                     module: 'sale_management',
                     module_name: '销售接单',
@@ -178,8 +191,21 @@ export default {
                 return this.$hasPermission(module.module);
             });
         },
+        export_column_options: function () {
+            return this.company_is_group
+                ? insert_supply_column(BASE_EXPORT_COLUMNS)
+                : [...BASE_EXPORT_COLUMNS];
+        },
     },
     methods: {
+        load_self_info: async function () {
+            try {
+                const ret = await this.$send_req('/global/self_info', {});
+                this.company_is_group = !!(ret && ret.company_is_group);
+            } catch (e) {
+                this.company_is_group = false;
+            }
+        },
         show_export_success: function () {
             this.$notify({
                 title: '导出成功',
@@ -310,6 +336,13 @@ export default {
                 console.error('Failed to parse columns_defined from localStorage:', error);
             }
         }
+        await this.load_self_info();
+        const opts = this.export_column_options;
+        let cols = this.columns_defined.filter((c) => opts.some((o) => o.name === c.name));
+        if (this.company_is_group && !cols.some((c) => c.name === 'supply_company')) {
+            cols = insert_supply_column(cols);
+        }
+        this.columns_defined = cols;
     },
 }
 </script>


### PR DESCRIPTION
1.修复集团的用户正常下单后点击订单弹出合同不存在的bug
2.修复集团用户分配物料时不显示子公司物料的bug
3.修复第三方下单看不到下单的bug
4.添加订单导出功能（有查看权限）导出货源公司的功能
非集团导出：
<img width="1153" height="603" alt="image" src="https://github.com/user-attachments/assets/39d4c78f-45d2-44cb-9c73-e1e6480ac882" />
集团导出：
<img width="1372" height="607" alt="image" src="https://github.com/user-attachments/assets/dab2dbf0-44b9-4ed4-ba22-bce2eb0975e9" />
