### PR TITLE
ZYZL-681-客户页面有无关的物料权限提示-需要去掉、

### DIFF
--- a/mt_pc/src/views/dashboard.vue
+++ b/mt_pc/src/views/dashboard.vue
@@ -227,6 +227,9 @@ export default {
             }
         },
         show_today_yesterday: async function () {
+            if (!this.$hasPermission('stuff')) {
+                return;
+            }
             this.stat_loading = true;
             let resp = await this.$send_req('/stuff/get_count_by_today_yesterday', {
                 stat_context_company_id: this.stat_context_company_id,


### PR DESCRIPTION
1.去掉无用提示