### PR TITLE
ZYZL-683-订单标记已排号

### DIFF
--- a/mt_gui/src/pages/OrderList.vue
+++ b/mt_gui/src/pages/OrderList.vue
@@ -70,6 +70,7 @@
                     <view slot="value" style="display:flex; flex-direction: column;">
                         <fui-tag theme="plain" :text="'计划:' + item.plan_time" :scaleRatio="0.8" type="danger"></fui-tag>
                         <fui-tag v-if="item.is_repeat" theme="plain" text="连续派车" :scaleRatio="0.8" type="warning"></fui-tag>
+                        <fui-tag v-if="item.register_time" theme="plain" text="已排号" :scaleRatio="0.8" type="primary"></fui-tag>
                         <fui-tag v-if="item.m_time" theme="plain" :text="'发车:' + item.m_time" :scaleRatio="0.8" type="primary"></fui-tag>
                         <fui-tag v-if="item.count && item.count != 0" theme="plain" :text="'装车量' + item.count" :scaleRatio="0.8" type="success"></fui-tag>
                         <fui-tag v-if="item.status == 1 && item.arrears > 0" theme="plain" :text="'欠款额:' + item.arrears + '需付'+ item.outstanding_vehicles + '车'" :scaleRatio="0.8" type="warning"></fui-tag>
@@ -172,6 +173,7 @@
                     </u-cell>
                     <u-cell :title="'当前状态：' + plan_status">
                         <view slot="value" style="display:flex;">
+                            <fui-tag v-if="focus_plan.register_time" theme="plain" text="已排号" :scaleRatio="0.8" type="primary"></fui-tag>
                             <module-filter :rm_array="['customer', 'supplier']"></module-filter>
                             <fui-button v-if="focus_plan.status != 3 && plan_owner" btnSize="mini" text="取消" type="danger" @click="prepare_xxx_confirm(cur_cancel_url, '取消')"></fui-button>
                             <module-filter :rm_array="['sale_management', 'buy_management']" style="display:flex;">

--- a/mt_gui/src/pages/OrderList.vue
+++ b/mt_gui/src/pages/OrderList.vue
@@ -70,7 +70,7 @@
                     <view slot="value" style="display:flex; flex-direction: column;">
                         <fui-tag theme="plain" :text="'计划:' + item.plan_time" :scaleRatio="0.8" type="danger"></fui-tag>
                         <fui-tag v-if="item.is_repeat" theme="plain" text="连续派车" :scaleRatio="0.8" type="warning"></fui-tag>
-                        <fui-tag v-if="item.register_time" theme="plain" text="已排号" :scaleRatio="0.8" type="primary"></fui-tag>
+                        <fui-tag v-if="item.register_time && item.status != 3" theme="plain" text="已排号" :scaleRatio="0.8" type="primary"></fui-tag>
                         <fui-tag v-if="item.m_time" theme="plain" :text="'发车:' + item.m_time" :scaleRatio="0.8" type="primary"></fui-tag>
                         <fui-tag v-if="item.count && item.count != 0" theme="plain" :text="'装车量' + item.count" :scaleRatio="0.8" type="success"></fui-tag>
                         <fui-tag v-if="item.status == 1 && item.arrears > 0" theme="plain" :text="'欠款额:' + item.arrears + '需付'+ item.outstanding_vehicles + '车'" :scaleRatio="0.8" type="warning"></fui-tag>
@@ -173,7 +173,7 @@
                     </u-cell>
                     <u-cell :title="'当前状态：' + plan_status">
                         <view slot="value" style="display:flex;">
-                            <fui-tag v-if="focus_plan.register_time" theme="plain" text="已排号" :scaleRatio="0.8" type="primary"></fui-tag>
+                            <fui-tag v-if="focus_plan.register_time && focus_plan.status != 3" theme="plain" text="已排号" :scaleRatio="0.8" type="primary"></fui-tag>
                             <module-filter :rm_array="['customer', 'supplier']"></module-filter>
                             <fui-button v-if="focus_plan.status != 3 && plan_owner" btnSize="mini" text="取消" type="danger" @click="prepare_xxx_confirm(cur_cancel_url, '取消')"></fui-button>
                             <module-filter :rm_array="['sale_management', 'buy_management']" style="display:flex;">

--- a/mt_pc/src/components/OrderShowTable.vue
+++ b/mt_pc/src/components/OrderShowTable.vue
@@ -101,7 +101,7 @@
                             <div>
                                 {{status_string(scope.row.status)}}
                             </div>
-                            <div v-if="scope.row.register_time">
+                            <div v-if="scope.row.register_time && scope.row.status != 3">
                                 <el-tag size="mini" type="danger">
                                     已排号
                                 </el-tag>

--- a/mt_pc/src/components/OrderShowTable.vue
+++ b/mt_pc/src/components/OrderShowTable.vue
@@ -101,6 +101,11 @@
                             <div>
                                 {{status_string(scope.row.status)}}
                             </div>
+                            <div v-if="scope.row.register_time">
+                                <el-tag size="mini" type="danger">
+                                    已排号
+                                </el-tag>
+                            </div>
                             <div v-if="scope.row.status == 3 && !scope.row.manual_close">
                                 <el-tag size="mini" type="primary">
                                     装卸量:{{scope.row.count}}


### PR DESCRIPTION
1.订单列表页面标记已排号
2.pc和gui端都添加
<img width="428" height="500" alt="image" src="https://github.com/user-attachments/assets/0b604d45-901c-4966-97a8-5ac0a8a47741" />
<img width="721" height="645" alt="image" src="https://github.com/user-attachments/assets/1c960140-36f9-482f-aeb1-453406774bc0" />
