### PR TITLE
ZYZL-678-首页的统计表格数字调整

### DIFF
--- a/api/module/sale_management_module.js
+++ b/api/module/sale_management_module.js
@@ -809,10 +809,12 @@ module.exports = {
                         },
                         confirm_count: { type: Number, mean: '确认订单数量', example: 1 },
                         finish_count: { type: Number, mean: '完成订单数量', example: 1 },
+                        cancel_count: { type: Number, mean: '取消订单数量', example: 1 },
                     }
                 },
                 total_confirm_count:{type: Number, mean: '确认订单总数量', example: 1},
                 total_finish_count:{type: Number, mean: '完成订单总数量', example: 1},
+                total_cancel_count:{type: Number, mean: '取消订单总数量', example: 1},
             },
             func: async function (body, token) {
                 let ret = [];
@@ -878,19 +880,34 @@ module.exports = {
                     let finish_count = await customer.countPlans({
                         where: tmp_cond
                     });
+                    let cancel_count = await customer.countPlans({
+                        where: {
+                            ...condition,
+                            status: 3,
+                            manual_close: true,
+                        }
+                    });
                     ret.push({
                         company: customer,
                         confirm_count: confirm_count,
-                        finish_count: finish_count
+                        finish_count: finish_count,
+                        cancel_count: cancel_count,
                     })
                 }
                 let total_confirm_count = 0;
                 let total_finish_count = 0;
+                let total_cancel_count = 0;
                 for (let i = 0; i < ret.length; i++) {
                     total_confirm_count += ret[i].confirm_count;
                     total_finish_count += ret[i].finish_count;
+                    total_cancel_count += ret[i].cancel_count;
                 }
-                return { statistic: ret, total_confirm_count: total_confirm_count, total_finish_count: total_finish_count };
+                return {
+                    statistic: ret,
+                    total_confirm_count: total_confirm_count,
+                    total_finish_count: total_finish_count,
+                    total_cancel_count: total_cancel_count,
+                };
             },
         },
         set_fapiao_delivered: {

--- a/mt_gui/src/pages/Home.vue
+++ b/mt_gui/src/pages/Home.vue
@@ -166,12 +166,8 @@ export default {
                 width: '400'
             }, {
                 prop: 'confirm_count',
-                label: '总车数',
-                width: '160'
-            }, {
-                prop: 'cancel_count',
-                label: '取消',
-                width: '160'
+                label: '总车数(取消)',
+                width: '200'
             }, {
                 prop: 'finish_count',
                 label: '完成数',
@@ -218,19 +214,21 @@ export default {
                 base_day: this.base_day,
                 stat_context_company_id: this.stat_context_company_id,
             });
+            let format_confirm_count = (confirm_count, cancel_count) => {
+                let cc = cancel_count || 0;
+                return cc > 0 ? `${confirm_count}(${cc})` : `${confirm_count}`;
+            };
             this.tableData = [];
             this.tableData.push({
                 company_name: '合计',
-                confirm_count: resp.total_confirm_count,
-                cancel_count: resp.total_cancel_count,
+                confirm_count: format_confirm_count(resp.total_confirm_count, resp.total_cancel_count),
                 finish_count: resp.total_finish_count,
             });
             for (let index = 0; index < resp.statistic.length; index++) {
                 const element = resp.statistic[index];
                 this.tableData.push({
                     company_name: element.company.name,
-                    confirm_count: element.confirm_count,
-                    cancel_count: element.cancel_count,
+                    confirm_count: format_confirm_count(element.confirm_count, element.cancel_count),
                     finish_count: element.finish_count,
                 })
             }

--- a/mt_gui/src/pages/Home.vue
+++ b/mt_gui/src/pages/Home.vue
@@ -169,6 +169,10 @@ export default {
                 label: '总车数',
                 width: '160'
             }, {
+                prop: 'cancel_count',
+                label: '取消',
+                width: '160'
+            }, {
                 prop: 'finish_count',
                 label: '完成数',
                 width: '160'
@@ -218,6 +222,7 @@ export default {
             this.tableData.push({
                 company_name: '合计',
                 confirm_count: resp.total_confirm_count,
+                cancel_count: resp.total_cancel_count,
                 finish_count: resp.total_finish_count,
             });
             for (let index = 0; index < resp.statistic.length; index++) {
@@ -225,6 +230,7 @@ export default {
                 this.tableData.push({
                     company_name: element.company.name,
                     confirm_count: element.confirm_count,
+                    cancel_count: element.cancel_count,
                     finish_count: element.finish_count,
                 })
             }

--- a/mt_pc/src/views/dashboard.vue
+++ b/mt_pc/src/views/dashboard.vue
@@ -40,6 +40,8 @@
                                 </el-table-column>
                                 <el-table-column prop="confirm_count" min-width="25" label="总数">
                                 </el-table-column>
+                                <el-table-column prop="cancel_count" min-width="25" label="取消">
+                                </el-table-column>
                                 <el-table-column prop="finish_count" min-width="25" label="完成">
                                 </el-table-column>
                             </el-table>


### PR DESCRIPTION
1.首页添加已经取消的订单统计量
<img width="379" height="517" alt="image" src="https://github.com/user-attachments/assets/8a21ac75-7f51-4629-8f82-7d97f2371e21" />
<img width="827" height="387" alt="image" src="https://github.com/user-attachments/assets/0b6d16b1-9e56-4dbc-9e90-9aa66ceacbe2" />