### PR TITLE
ZYZL-684-集团角度订单中心的过滤选项

### DIFF
--- a/api/module/sale_management_module.js
+++ b/api/module/sale_management_module.js
@@ -364,12 +364,14 @@ module.exports = {
                 if (!context_company || !home_company) {
                     return { stuff: [], total: 0 };
                 }
-                const group_company = home_company.is_group ? home_company : context_company;
-                let company_ids = [group_company.id];
-                if (group_company.is_group) {
+                // 统计范围切换到成员公司时，仅返回该成员公司的物料；
+                // 统计范围是集团公司时，返回集团及其可见成员公司物料。
+                const scope_company = context_company;
+                let company_ids = [scope_company.id];
+                if (scope_company.is_group) {
                     const user = await rbac_lib.get_user_by_token(token);
                     if (user) {
-                        const member_ids = await group_lib.list_member_company_ids_for_stuff(user.id, group_company);
+                        const member_ids = await group_lib.list_member_company_ids_for_stuff(user.id, scope_company);
                         company_ids.push(...member_ids);
                     }
                 }
@@ -387,7 +389,10 @@ module.exports = {
                     limit: 20,
                 });
                 ret.rows.forEach((item) => {
-                    if (group_company.is_group && item.companyId !== group_company.id && item.company) {
+                    const should_prefix_member_company_name = home_company.is_group
+                        && item.company
+                        && item.company.id !== home_company.id;
+                    if (should_prefix_member_company_name) {
                         item.name = `${item.company.name}-${item.name}`;
                     }
                 });

--- a/mt_gui/src/pages/OrderList.vue
+++ b/mt_gui/src/pages/OrderList.vue
@@ -6,12 +6,12 @@
         <fui-row :gutter="20">
             <fui-col :span="16" v-if="!select_active">
                 <module-filter :rm_array="['sale_management', 'buy_management']">
-                    <fui-tag theme="plain" type="purple" @click="show_stuff_list = true" marginLeft="20">
+                    <fui-tag theme="plain" type="purple" @click="open_stuff_filter" marginLeft="20">
                         {{stuff_filter.name}}
                         <fui-icon v-if="!stuff_filter.id" name="arrowright" size="32"></fui-icon>
                         <fui-icon v-else name="close" size="32" @click.native.stop="reset_stuff_filter"></fui-icon>
                     </fui-tag>
-                    <fui-tag theme="plain" type="success" @click="show_company_filter = true" marginLeft="20">
+                    <fui-tag theme="plain" type="success" @click="open_company_filter" marginLeft="20">
                         {{company_filter.name}}
                         <fui-icon v-if="!company_filter.id" name="arrowright" size="32"></fui-icon>
                         <fui-icon v-else name="close" size="32" @click.native.stop="reset_company_filter"></fui-icon>
@@ -99,7 +99,7 @@
     <module-filter require_module="stuff">
         <fui-bottom-popup :show="show_stuff_list" @close="show_stuff_list = false">
             <fui-list>
-                <list-show v-model="stuff_data2show" :fetch_function="get_stuff" search_key="name" height="40vh">
+                <list-show ref="stuff_filter_list" v-model="stuff_data2show" :fetch_function="get_stuff" :fetch_params="[show_sale_scope_switch, stat_context_company_id]" search_key="name" height="40vh">
                     <fui-list-cell arrow v-for="item in stuff_data2show" :key="item.id" @click="choose_stuff(item)">
                         {{item.name}}
                     </fui-list-cell>
@@ -108,7 +108,7 @@
         </fui-bottom-popup>
         <fui-bottom-popup :show="show_company_filter" @close="show_company_filter= false">
             <fui-list>
-                <list-show v-model="customer_data2show" :fetch_function="get_customers" search_key="search_cond" height="40vh" :fetch_params="[make_context_req, show_sale_scope_switch, stat_context_company_id]">
+                <list-show ref="company_filter_list" v-model="customer_data2show" :fetch_function="get_customers" search_key="search_cond" height="40vh" :fetch_params="[make_context_req, show_sale_scope_switch, stat_context_company_id]">
                     <fui-list-cell arrow v-for="item in customer_data2show" :key="item.id" @click="choose_company(item)">
                         {{item.company.name}}
                     </fui-list-cell>
@@ -789,6 +789,22 @@ export default {
         open_scope_picker: function () {
             this.show_scope_picker = true;
         },
+        open_stuff_filter: function () {
+            this.show_stuff_list = true;
+            this.$nextTick(() => {
+                if (this.$refs.stuff_filter_list) {
+                    this.$refs.stuff_filter_list.refresh();
+                }
+            });
+        },
+        open_company_filter: function () {
+            this.show_company_filter = true;
+            this.$nextTick(() => {
+                if (this.$refs.company_filter_list) {
+                    this.$refs.company_filter_list.refresh();
+                }
+            });
+        },
         choose_stat_scope: function (company_id) {
             if (this.stat_context_company_id === company_id) {
                 this.show_scope_picker = false;
@@ -796,6 +812,22 @@ export default {
             }
             this.stat_context_company_id = company_id;
             this.show_scope_picker = false;
+            this.company_filter = {
+                name: '全部公司',
+                id: undefined,
+            };
+            this.stuff_filter = {
+                name: '全部物料',
+                id: undefined,
+            };
+            this.$nextTick(() => {
+                if (this.$refs.company_filter_list) {
+                    this.$refs.company_filter_list.refresh();
+                }
+                if (this.$refs.stuff_filter_list) {
+                    this.$refs.stuff_filter_list.refresh();
+                }
+            });
             this.refresh_plans();
         },
         make_context_req: function (body = {}, url = '', ssss_bool = false, scci = null) {
@@ -1591,14 +1623,20 @@ export default {
                 single_tab.badge = res.total;
             }
         },
-        get_stuff: async function (pageNo) {
+        get_stuff: async function (pageNo, [ssss_bool, scci]) {
             let mods = uni.getStorageSync('self_info').modules.map(ele => {
                 return ele.name
             })
             if (mods.indexOf('stuff') != -1) {
-                let ret = await this.$send_req('/stuff/get_all', {
+                let req_url = '/stuff/get_all';
+                let req_body = {
                     pageNo: pageNo
-                });
+                };
+                if (ssss_bool && scci != null) {
+                    req_url = '/sale_management/get_stuff_for_contract';
+                    req_body.stat_context_company_id = scci;
+                }
+                let ret = await this.$send_req(req_url, req_body);
                 return ret.stuff;
             } else {
                 return [];

--- a/mt_pc/src/components/ContractShowTable.vue
+++ b/mt_pc/src/components/ContractShowTable.vue
@@ -1,14 +1,13 @@
 <template>
 <div>
-    <el-radio-group
+    <group-stat-scope-selector
         v-if="show_stat_scope_selector && stat_scopes.length > 1"
         v-model="stat_context_company_id"
-        size="small"
-        style="margin-right: 10px;"
+        :scopes="stat_scopes"
+        :home-company-id="self_info && self_info.company_id"
+        class="contract_scope_selector"
         @change="on_scope_change"
-    >
-        <el-radio-button v-for="s in stat_scopes" :key="s.id" :label="s.id">{{ s.name }}</el-radio-button>
-    </el-radio-group>
+    />
     <el-button v-if="is_motive" icon="el-icon-circle-plus" type="success" @click="prepare_new_contract">新增合同</el-button>
     <el-button
         v-if="can_manage_discount"
@@ -233,6 +232,7 @@
 <script>
 import page_content from './PageContent.vue';
 import SelectSearch from './SelectSearch.vue';
+import GroupStatScopeSelector from './GroupStatScopeSelector.vue';
 export default {
     name: 'ContractShowTable',
     data: function () {
@@ -293,6 +293,7 @@ export default {
         'page-content': page_content,
         'el-image-viewer': () => import('element-ui/packages/image/src/image-viewer'),
         'select-search': SelectSearch,
+        'group-stat-scope-selector': GroupStatScopeSelector,
     },
     props: {
         req_path: String,
@@ -361,7 +362,8 @@ export default {
                 const ret = await this.$send_req('/global/home_stat_scope_list', {});
                 this.stat_scopes = ret.scopes || [];
                 if (this.stat_scopes.length && this.stat_context_company_id == null) {
-                    this.stat_context_company_id = this.stat_scopes[0].id;
+                    const first_member_scope = this.stat_scopes.find((s) => this.self_info && s.id !== this.self_info.company_id);
+                    this.stat_context_company_id = first_member_scope ? first_member_scope.id : this.stat_scopes[0].id;
                     this.$nextTick(() => {
                         if (this.$refs.contracts) {
                             this.$refs.contracts.refresh(1);
@@ -667,6 +669,8 @@ export default {
 }
 </script>
 
-<style>
-
+<style scoped>
+.contract_scope_selector {
+    margin-right: 10px;
+}
 </style>

--- a/mt_pc/src/components/GroupStatScopeSelector.vue
+++ b/mt_pc/src/components/GroupStatScopeSelector.vue
@@ -1,0 +1,96 @@
+<template>
+    <div class="group_scope" v-if="visible && scopes.length > 1">
+        <span v-if="showLabel" class="scope_label">{{ label }}</span>
+        <el-radio-group :value="value" :size="size" @input="on_input" @change="on_change">
+            <el-radio-button v-for="s in scopes" :key="s.id" :label="s.id"
+                :class="{ scope_home_btn: is_home_scope(s) }">
+                {{ s.name }}
+                <span v-if="is_home_scope(s)" class="scope_home_mark">主</span>
+            </el-radio-button>
+        </el-radio-group>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'GroupStatScopeSelector',
+    props: {
+        value: {
+            type: [Number, String],
+            default: null,
+        },
+        scopes: {
+            type: Array,
+            default: function () {
+                return [];
+            }
+        },
+        homeCompanyId: {
+            type: Number,
+            default: null,
+        },
+        label: {
+            type: String,
+            default: '统计范围',
+        },
+        showLabel: {
+            type: Boolean,
+            default: true,
+        },
+        size: {
+            type: String,
+            default: 'small',
+        },
+        visible: {
+            type: Boolean,
+            default: true,
+        }
+    },
+    methods: {
+        is_home_scope: function (scope) {
+            return this.homeCompanyId != null && scope && scope.id === this.homeCompanyId;
+        },
+        on_input: function (val) {
+            this.$emit('input', val);
+        },
+        on_change: function (val) {
+            this.$emit('change', val);
+        }
+    }
+}
+</script>
+
+<style scoped>
+.group_scope {
+    display: inline-flex;
+    align-items: center;
+}
+
+.scope_label {
+    color: #606266;
+    font-size: 14px;
+    margin-right: 10px;
+}
+
+.group_scope ::v-deep .scope_home_btn.is-active .el-radio-button__inner {
+    background: #f56c6c;
+    border-color: #f56c6c;
+    color: #fff;
+    box-shadow: -1px 0 0 0 #f56c6c;
+}
+
+.group_scope ::v-deep .scope_home_mark {
+    margin-left: 4px;
+    padding: 0 4px;
+    border-radius: 8px;
+    font-size: 12px;
+    line-height: 16px;
+    color: #f56c6c;
+    background: #fff2f0;
+}
+
+.group_scope ::v-deep .scope_home_btn.is-active .scope_home_mark {
+    color: #f56c6c;
+    background: #ffffff;
+}
+</style>

--- a/mt_pc/src/components/OrderShowTable.vue
+++ b/mt_pc/src/components/OrderShowTable.vue
@@ -1,11 +1,12 @@
 <template>
 <div class="order_show">
-    <div v-if="show_sale_scope_selector && stat_scopes.length > 1" class="scope_bar">
-        <span class="scope_label">统计范围</span>
-        <el-radio-group v-model="stat_context_company_id" size="small" @change="refresh_order">
-            <el-radio-button v-for="s in stat_scopes" :key="s.id" :label="s.id">{{ s.name }}</el-radio-button>
-        </el-radio-group>
-    </div>
+    <group-stat-scope-selector
+        v-if="show_sale_scope_selector && stat_scopes.length > 1"
+        v-model="stat_context_company_id"
+        :scopes="stat_scopes"
+        :home-company-id="self_info && self_info.company_id"
+        @change="on_stat_scope_change"
+    />
     <div class="filter_bar">
         <el-tabs v-model="status" @tab-click="refresh_order">
             <el-tab-pane label="全部" name="all"></el-tab-pane>
@@ -53,8 +54,8 @@
             </el-dropdown-menu>
         </el-dropdown>
         <div style="display:flex;">
-            <select-search filterable body_key="contracts" first_item="所有公司" :get_url="contract_get_url" :req_body="contract_req_body" item_label="company.name" item_value="company.id" :permission_array="['sale_management', 'stuff_management']" v-model="company_id" @refresh="refresh_order"></select-search>
-            <select-search body_key="stuff" first_item="所有物料" get_url="/stuff/get_all" item_label="name" item_value="id" :permission_array="['stuff']" v-model="stuff_id" @refresh="refresh_order"></select-search>
+            <select-search ref="company_selector" :key="company_selector_key" filterable body_key="contracts" first_item="所有公司" :get_url="contract_get_url" :req_body="contract_req_body" item_label="company.name" item_value="company.id" :permission_array="['sale_management', 'stuff_management']" v-model="company_id" @refresh="refresh_order"></select-search>
+            <select-search ref="stuff_selector" :key="stuff_selector_key" body_key="stuff" first_item="所有物料" :get_url="stuff_get_url" :req_body="stuff_req_body" item_label="name" item_value="id" :permission_array="stuff_permission_array" v-model="stuff_id" @refresh="refresh_order"></select-search>
             <el-input placeholder="输入车号过滤" v-model="filter_string" style="width: 250px;">
                 <div slot="suffix">
                     <el-button type="primary" size="small" @click="do_search">搜索</el-button>
@@ -147,12 +148,14 @@ import page_content from './PageContent.vue';
 import moment from 'moment';
 import SelectSearch from './SelectSearch.vue';
 import OrderDetail from './OrderDetail.vue';
+import GroupStatScopeSelector from './GroupStatScopeSelector.vue';
 export default {
     name: 'OrderShowTable',
     components: {
         'page-content': page_content,
         'select-search': SelectSearch,
         'order-detail': OrderDetail,
+        'group-stat-scope-selector': GroupStatScopeSelector,
     },
     computed: {
         show_sale_scope_selector: function () {
@@ -176,6 +179,30 @@ export default {
             } else {
                 return '/sale_management/contract_get';
             }
+        },
+        stuff_get_url: function () {
+            if (this.show_sale_scope_selector) {
+                return '/sale_management/get_stuff_for_contract';
+            }
+            return '/stuff/get_all';
+        },
+        stuff_req_body: function () {
+            if (this.show_sale_scope_selector) {
+                return this.make_context_req({});
+            }
+            return {};
+        },
+        stuff_permission_array: function () {
+            if (this.show_sale_scope_selector) {
+                return ['sale_management', 'stuff'];
+            }
+            return ['stuff'];
+        },
+        company_selector_key: function () {
+            return `company-${this.stat_context_company_id || 'default'}-${this.filter_selector_refresh_seed}`;
+        },
+        stuff_selector_key: function () {
+            return `stuff-${this.stat_context_company_id || 'default'}-${this.filter_selector_refresh_seed}`;
         }
     },
     data: function () {
@@ -216,6 +243,7 @@ export default {
             pickerOptions: this.$quik_date_option,
             stat_scopes: [],
             stat_context_company_id: null,
+            filter_selector_refresh_seed: 0,
             self_info: {
                 company_is_group: false,
                 company_id: null,
@@ -279,7 +307,8 @@ export default {
                 const ret = await this.$send_req('/global/home_stat_scope_list', {});
                 this.stat_scopes = ret.scopes || [];
                 if (this.stat_scopes.length && this.stat_context_company_id == null) {
-                    this.stat_context_company_id = this.stat_scopes[0].id;
+                    const first_member_scope = this.stat_scopes.find((s) => this.self_info && s.id !== this.self_info.company_id);
+                    this.stat_context_company_id = first_member_scope ? first_member_scope.id : this.stat_scopes[0].id;
                 }
             } catch (e) {
                 this.stat_scopes = [];
@@ -420,6 +449,14 @@ export default {
                 hide_manual_close: false,
             }, true)).total;
         },
+        on_stat_scope_change: function () {
+            if (this.show_sale_scope_selector) {
+                this.company_id = 0;
+                this.stuff_id = 0;
+                this.filter_selector_refresh_seed += 1;
+            }
+            this.refresh_order();
+        },
         refresh_order: function () {
             if (this.stuff_id != 0) {
                 this.filter.stuff_id = this.stuff_id;
@@ -510,15 +547,8 @@ export default {
     align-items: center;
 }
 
-.scope_bar {
-    display: flex;
-    align-items: center;
+.group_scope {
     margin-bottom: 8px;
 }
 
-.scope_label {
-    color: #606266;
-    font-size: 14px;
-    margin-right: 10px;
-}
 </style>

--- a/mt_pc/src/views/dashboard.vue
+++ b/mt_pc/src/views/dashboard.vue
@@ -2,10 +2,12 @@
 <div class="dashboard-container">
     <el-row v-if="stat_scopes.length > 1" :gutter="10" class="stat-scope-row">
         <el-col :span="24">
-            <span class="stat-scope-label">统计范围</span>
-            <el-radio-group v-model="stat_context_company_id" size="small" @change="on_stat_scope_change">
-                <el-radio-button v-for="s in stat_scopes" :key="s.id" :label="s.id">{{ s.name }}</el-radio-button>
-            </el-radio-group>
+            <group-stat-scope-selector
+                v-model="stat_context_company_id"
+                :scopes="stat_scopes"
+                :home-company-id="home_scope_company_id"
+                @change="on_stat_scope_change"
+            />
         </el-col>
     </el-row>
     <el-row :gutter="10">
@@ -147,6 +149,7 @@ import {
 } from 'vuex'
 import ChartComponent from '../components/Charts.vue';
 import page_content from '../components/PageContent.vue';
+import GroupStatScopeSelector from '../components/GroupStatScopeSelector.vue';
 import moment from 'moment';
 
 export default {
@@ -154,6 +157,7 @@ export default {
     components: {
         ChartComponent,
         'page-content': page_content,
+        'group-stat-scope-selector': GroupStatScopeSelector,
     },
     computed: {
         ...mapGetters([
@@ -191,6 +195,7 @@ export default {
             ss_url: '/supplier/get_stuff_need_buy',
             stat_scopes: [],
             stat_context_company_id: null,
+            home_scope_company_id: null,
         }
     },
     async mounted() {
@@ -205,6 +210,9 @@ export default {
             try {
                 const ret = await this.$send_req('/global/home_stat_scope_list', {});
                 this.stat_scopes = ret.scopes || [];
+                if (this.stat_scopes.length) {
+                    this.home_scope_company_id = this.stat_scopes[0].id;
+                }
                 if (this.stat_scopes.length && this.stat_context_company_id == null) {
                     this.stat_context_company_id = this.stat_scopes[0].id;
                 }
@@ -472,11 +480,5 @@ export default {
 
 .stat-scope-row {
     margin-bottom: 10px;
-}
-.stat-scope-label {
-    margin-right: 12px;
-    color: #606266;
-    font-size: 14px;
-    vertical-align: middle;
 }
 </style>


### PR DESCRIPTION
1.订单中心添加集团角度过滤选项
2.pc和gui端都添加
3.将统计范围封装为一个组件
4.美化样式，主体公司和成员公司用作区分
5.销售接单和销售合同签订 进入后默认选中第一个成员公司
<img width="429" height="895" alt="image" src="https://github.com/user-attachments/assets/6d2467ad-4526-400a-a421-d9b66f16eca7" />

<img width="1213" height="450" alt="image" src="https://github.com/user-attachments/assets/9d7bd994-2237-4b30-8807-23ba3435cc34" />
<img width="1351" height="498" alt="image" src="https://github.com/user-attachments/assets/6e21b0e8-ebd6-45f7-abeb-13772a5cae1c" />
