### PR TITLE
ZYZL-686-基于物料改价时的额外逻辑

### DIFF
--- a/api/lib/plan_lib.js
+++ b/api/lib/plan_lib.js
@@ -1656,8 +1656,39 @@ module.exports = {
             const sq = db_opt.get_sq();
             for (let index = 0; index < plans.length; index++) {
                 const element = plans[index];
+                let target_unit_price = _new_price;
+                let should_skip_update = false;
+                // 按合同配置重算计划单价，严格遵循两条规则：
+                // 1) 若存在合同维度物料单价（一客一价 contract_stuff_price），则保持原订单单价不变；
+                // 2) 否则若合同绑定了优惠方案，则按 新物料价 + 方案delta 重算后写回；
+                // 3) 以上都不命中时，沿用新物料价 _new_price。
+                if (element && element.companyId) {
+                    let contracts = await this.get_sale_contracts_for_buyer_and_supply_company(
+                        element.companyId,
+                        stuff.companyId
+                    );
+                    contracts = this.pick_sale_contracts_for_supply(contracts, stuff.companyId);
+                    if (contracts.length > 1) {
+                        contracts.sort((a, b) => (b.id || 0) - (a.id || 0));
+                    }
+                    const picked_contract = contracts.length > 0 ? contracts[0] : null;
+                    if (picked_contract) {
+                        const override_price = await this.get_contract_stuff_price(picked_contract.id, stuff.id);
+                        if (override_price) {
+                            should_skip_update = true;
+                        } else if (picked_contract.discountSchemeId) {
+                            const scheme = await sq.models.contract_discount_scheme.findByPk(picked_contract.discountSchemeId);
+                            if (scheme) {
+                                target_unit_price = Number((Number(_new_price) + Number(scheme.delta_price)).toFixed(2));
+                            }
+                        }
+                    }
+                }
+                if (should_skip_update) {
+                    continue;
+                }
                 const [affected_rows] = await sq.models.plan.update(
-                    { unit_price: _new_price },
+                    { unit_price: target_unit_price },
                     {
                         where: {
                             id: element.id,
@@ -1670,7 +1701,7 @@ module.exports = {
                     continue;
                 }
                 const updated_plan = await util_lib.get_single_plan_by_id(element.id);
-                await this.rp_history_price_change(updated_plan, _operator, _new_price);
+                await this.rp_history_price_change(updated_plan, _operator, target_unit_price);
                 if (updated_plan.companyId && company_ids.indexOf(updated_plan.companyId) == -1) {
                     company_ids.push(updated_plan.companyId);
                 }

--- a/automation/group/group_contract_price_strategy.robot
+++ b/automation/group/group_contract_price_strategy.robot
@@ -68,6 +68,7 @@ Setup Group Contract Price Scenario
 
     Set Suite Variable  ${PARENT_TOKEN}  ${parent_token}
     Set Suite Variable  ${BUYER_TOKEN}  ${buyer_token}
+    Set Suite Variable  ${MEMBER_TOKEN}  ${member_token}
     Set Suite Variable  ${MEMBER_COMPANY}  ${member}
     Set Suite Variable  ${MEMBER_STUFF}  ${member_stuff}
     Set Suite Variable  ${CONTRACT}  ${contract}
@@ -124,6 +125,20 @@ Create Buyer Plan With Member Stuff
     ${plan}  Req to Server  /customer/order_buy_create  ${BUYER_TOKEN}  ${create_req}
     RETURN  ${plan}
 
+Get Buyer Plan By Id
+    [Arguments]  ${token}  ${plan_id}
+    ${req}  Create Dictionary  start_time=2018-01-01  end_time=2090-09-09  status=${null}
+    ${plans}  Req Get to Server  /customer/order_buy_search  ${token}  plans  ${-1}  &{req}
+    ${found_plan}  Set Variable  ${None}
+    FOR  ${p}  IN  @{plans}
+        IF  ${p}[id] == ${plan_id}
+            ${found_plan}  Set Variable  ${p}
+            Exit For Loop
+        END
+    END
+    Should Not Be Empty  ${found_plan}
+    RETURN  ${found_plan}
+
 *** Test Cases ***
 Group CanOperate User Can Set Scheme And Stuff Override Price
     [Setup]  Setup Group Contract Price Scenario  ${True}
@@ -167,6 +182,84 @@ Group CanOperate User Price Falls Back To Scheme When No Override
 
     ${plan}  Create Buyer Plan With Member Stuff  ${12}
     Should Be Equal As Numbers  ${plan}[unit_price]  98.4
+
+Stuff Change Price ToPlan Keeps Contract Override Unit Price
+    [Setup]  Setup Group Contract Price Scenario  ${True}
+    ${save_scheme_req}  Create Dictionary
+    ...  name=单价-1.6元
+    ...  delta_price=${-1.6}
+    ...  stat_context_company_id=${MEMBER_COMPANY}[id]
+    Req to Server  /sale_management/discount_scheme_upsert  ${PARENT_TOKEN}  ${save_scheme_req}
+    ${scheme_id}  Find Discount Scheme Id By Name  ${PARENT_TOKEN}  ${MEMBER_COMPANY}[id]  单价-1.6元
+
+    ${set_scheme_req}  Create Dictionary
+    ...  contract_id=${CONTRACT}[id]
+    ...  scheme_id=${scheme_id}
+    ...  stat_context_company_id=${MEMBER_COMPANY}[id]
+    Req to Server  /sale_management/contract_set_discount_scheme  ${PARENT_TOKEN}  ${set_scheme_req}
+
+    ${set_override_req}  Create Dictionary
+    ...  contract_id=${CONTRACT}[id]
+    ...  stuff_id=${MEMBER_STUFF}[id]
+    ...  unit_price=${97.5}
+    ...  stat_context_company_id=${MEMBER_COMPANY}[id]
+    Req to Server  /sale_management/contract_set_stuff_price  ${PARENT_TOKEN}  ${set_override_req}
+
+    ${plan}  Create Buyer Plan With Member Stuff  ${21}
+    Should Be Equal As Numbers  ${plan}[unit_price]  97.5
+
+    ${change_req}  Create Dictionary
+    ...  stuff_id=${MEMBER_STUFF}[id]
+    ...  price=${109}
+    ...  to_plan=${True}
+    ...  comment=to_plan_keep_override
+    Req to Server  /stuff/change_price  ${MEMBER_TOKEN}  ${change_req}
+
+    ${plan_after}  Get Buyer Plan By Id  ${BUYER_TOKEN}  ${plan}[id]
+    Should Be Equal As Numbers  ${plan_after}[unit_price]  97.5
+
+Stuff Change Price ToPlan Uses Discount Scheme Unit Price
+    [Setup]  Setup Group Contract Price Scenario  ${True}
+    ${save_scheme_req}  Create Dictionary
+    ...  name=单价-1.6元
+    ...  delta_price=${-1.6}
+    ...  stat_context_company_id=${MEMBER_COMPANY}[id]
+    Req to Server  /sale_management/discount_scheme_upsert  ${PARENT_TOKEN}  ${save_scheme_req}
+    ${scheme_id}  Find Discount Scheme Id By Name  ${PARENT_TOKEN}  ${MEMBER_COMPANY}[id]  单价-1.6元
+
+    ${set_scheme_req}  Create Dictionary
+    ...  contract_id=${CONTRACT}[id]
+    ...  scheme_id=${scheme_id}
+    ...  stat_context_company_id=${MEMBER_COMPANY}[id]
+    Req to Server  /sale_management/contract_set_discount_scheme  ${PARENT_TOKEN}  ${set_scheme_req}
+
+    ${plan}  Create Buyer Plan With Member Stuff  ${22}
+    Should Be Equal As Numbers  ${plan}[unit_price]  98.4
+
+    ${change_req}  Create Dictionary
+    ...  stuff_id=${MEMBER_STUFF}[id]
+    ...  price=${109}
+    ...  to_plan=${True}
+    ...  comment=to_plan_apply_scheme
+    Req to Server  /stuff/change_price  ${MEMBER_TOKEN}  ${change_req}
+
+    ${plan_after}  Get Buyer Plan By Id  ${BUYER_TOKEN}  ${plan}[id]
+    Should Be Equal As Numbers  ${plan_after}[unit_price]  107.4
+
+Stuff Change Price ToPlan Uses New Price Without Contract Strategy
+    [Setup]  Setup Group Contract Price Scenario  ${True}
+    ${plan}  Create Buyer Plan With Member Stuff  ${23}
+    Should Be Equal As Numbers  ${plan}[unit_price]  100
+
+    ${change_req}  Create Dictionary
+    ...  stuff_id=${MEMBER_STUFF}[id]
+    ...  price=${109}
+    ...  to_plan=${True}
+    ...  comment=to_plan_apply_new_price
+    Req to Server  /stuff/change_price  ${MEMBER_TOKEN}  ${change_req}
+
+    ${plan_after}  Get Buyer Plan By Id  ${BUYER_TOKEN}  ${plan}[id]
+    Should Be Equal As Numbers  ${plan_after}[unit_price]  109
 
 Group ViewOnly User Cannot Configure Member Company Price Strategy
     [Setup]  Setup Group Contract Price Scenario  ${False}

--- a/mt_gui/src/subPage1/Stuff.vue
+++ b/mt_gui/src/subPage1/Stuff.vue
@@ -313,6 +313,13 @@
             <fui-form-item label="影响计划？" asterisk v-if="!price_profile.hide_impact_selector">
                 <u-switch v-model="stuff2change_price.to_plan"></u-switch>
             </fui-form-item>
+            <view v-if="stuff2change_price.to_plan"
+                style="margin: 8px 12px; padding: 10px; background: #FFF7E6; border: 1px solid #FFD591; border-radius: 4px; color: #874D00; font-size: 24rpx; line-height: 1.6;">
+                <view style="font-weight: bold; margin-bottom: 4px;">勾选"影响计划"后，未关闭订单的单价将按以下规则重算：</view>
+                <view>1. 合同已设置"一客一价"的订单：<text style="font-weight: bold;">保持原单价不变</text></view>
+                <view>2. 合同绑定了"优惠方案"的订单：按 <text style="font-weight: bold;">新价格 + 方案 delta</text> 重算</view>
+                <view>3. 其它订单：直接使用<text style="font-weight: bold;">新价格</text></view>
+            </view>
         </fui-form>
     </fui-modal>
     <fui-modal width="600" :show="show_next_price" v-if="show_next_price" @click="do_next_price">

--- a/mt_pc/src/components/ContractShowTable.vue
+++ b/mt_pc/src/components/ContractShowTable.vue
@@ -202,6 +202,13 @@
         </el-table>
     </el-dialog>
     <el-dialog title="设置合同优惠方案" :visible.sync="show_contract_scheme_dialog" width="30%">
+        <el-alert type="info" :closable="false" show-icon style="margin-bottom: 12px;">
+            <template slot="title">单价计算优先级</template>
+            <div style="font-size: 12px; line-height: 1.6;">
+                若该合同同时设置了"合同物料单价（一客一价）"，则<b>一客一价优先</b>，本方案不会生效；<br />
+                仅当未设置一客一价时，下单单价 = <b>物料基价 + 方案 delta</b>。
+            </div>
+        </el-alert>
         <el-select v-model="selected_scheme_id" clearable placeholder="请选择优惠方案" style="width: 100%;">
             <el-option v-for="item in discount_schemes" :key="item.id" :label="`${item.name}（${item.delta_price}）`" :value="item.id"></el-option>
         </el-select>
@@ -211,6 +218,13 @@
         </span>
     </el-dialog>
     <el-dialog title="设置合同物料单价" :visible.sync="show_stuff_price_dialog" width="40%">
+        <el-alert type="warning" :closable="false" show-icon style="margin-bottom: 12px;">
+            <template slot="title">一客一价说明</template>
+            <div style="font-size: 12px; line-height: 1.6;">
+                设置后该合同此物料的下单单价将<b>固定为此处单价</b>，并覆盖优惠方案；<br />
+                后续物料基价被调整且勾选"影响计划"时，该合同对应的未关闭订单单价<b>不会被覆盖</b>。
+            </div>
+        </el-alert>
         <el-table :data="stuff_price_rows" stripe>
             <el-table-column prop="name" label="物料"></el-table-column>
             <el-table-column label="单价">

--- a/mt_pc/src/views/stuff/StuffConfig.vue
+++ b/mt_pc/src/views/stuff/StuffConfig.vue
@@ -219,6 +219,17 @@
                 <el-form-item label="影响计划？" v-if="!price_profile.hide_impact_selector">
                     <el-switch v-model="stuff2change_price.to_plan"></el-switch>
                 </el-form-item>
+                <el-alert v-if="stuff2change_price.to_plan" type="warning" :closable="false" show-icon
+                    style="margin-bottom: 12px;">
+                    <template slot="title">
+                        勾选"影响计划"后，未关闭订单的单价将按以下规则重算：
+                    </template>
+                    <div style="font-size: 12px; line-height: 1.6;">
+                        1. 客户合同已设置"合同物料单价（一客一价）"的订单：<b>保持原单价不变</b>，不会被新价格覆盖；<br />
+                        2. 客户合同绑定了"优惠方案"的订单：按 <b>新价格 + 方案 delta</b> 重算后写回；<br />
+                        3. 既无一客一价、也无优惠方案的订单：直接使用<b>新价格</b>。
+                    </div>
+                </el-alert>
                 <el-form-item>
                     <el-button type="primary" @click="change_price">确定</el-button>
                     <el-button @click="show_change_price = false">取消</el-button>


### PR DESCRIPTION
1是否存在基于合同设定的单价，若设定过，则不应该改掉该订单的单价
2是否存在优惠方案，若存在则需要计算优惠后再设定为订单的单价