### PR TITLE
ZYZL-702-增加基于物料的自动确认配置

### DIFF
--- a/api/api_param_result_define.js
+++ b/api/api_param_result_define.js
@@ -305,6 +305,7 @@ module.exports = {
                 },
                 manual_weight: { type: Boolean, mean: '是否需要手动计量', example: false },
                 auto_confirm_goods: { type: Boolean, mean: '是否自动确认装卸货', example: false },
+                auto_confirm_order: { type: Boolean, mean: '是否自动确认订单', example: false },
                 checkout_delay: { type: Boolean, mean: '是否需要延迟结算', example: false },
                 ticket_prefix: { type: String, mean: '磅单号前缀', example: 'LNG' },
                 need_expect_weight: { type: Boolean, mean: '是否需要预计重量', example: false },

--- a/api/db_opt.js
+++ b/api/db_opt.js
@@ -240,6 +240,7 @@ let db_opt = {
             coefficient: { type: DataTypes.DECIMAL(12, 2), defaultValue: 1.00, get: getDecimalValue('coefficient') },
             add_base: { type: DataTypes.STRING },
             auto_confirm_goods: { type: DataTypes.BOOLEAN, defaultValue: false },
+            auto_confirm_order: { type: DataTypes.BOOLEAN, defaultValue: false },
             second_unit_decimal: { type: DataTypes.INTEGER, defaultValue: 2 },
             delay_checkout_time: { type: DataTypes.STRING },
             last_delay_checkout: { type: DataTypes.STRING },

--- a/api/lib/plan_lib.js
+++ b/api/lib/plan_lib.js
@@ -154,10 +154,15 @@ module.exports = {
         let driver_found = await sq.models.driver.findOrCreate({ where: { phone: _phone }, defaults: { name: _name, id_card: _id_card } });
         return driver_found[0];
     },
-    fetch_stuff: async function (_name, _comment, _company, _expect_count, use_for_buy, close_time, delay_days, concern_fapiao, stuff_code, close_today) {
+    fetch_stuff: async function (_name, _comment, _company, _expect_count, use_for_buy, close_time, delay_days, concern_fapiao, stuff_code, close_today, auto_confirm_order) {
         let sq = db_opt.get_sq();
         if (use_for_buy == undefined) {
             use_for_buy = false;
+        }
+        if (!use_for_buy) {
+            auto_confirm_order = false;
+        } else if (auto_confirm_order == undefined) {
+            auto_confirm_order = false;
         }
         let stuff_found = await _company.getStuff({ where: { name: _name, use_for_buy: use_for_buy } });
         if (stuff_found.length != 1) {
@@ -175,6 +180,7 @@ module.exports = {
             stuff_found[0].concern_fapiao = concern_fapiao;
             stuff_found[0].stuff_code = stuff_code;
             stuff_found[0].close_today = close_today;
+            stuff_found[0].auto_confirm_order = auto_confirm_order;
             await stuff_found[0].save();
             ret = stuff_found[0].toJSON();
         }

--- a/api/module/customer_module.js
+++ b/api/module/customer_module.js
@@ -242,6 +242,9 @@ module.exports = {
                     await new_plan.save();
                     plan_lib.mark_dup_info(new_plan.id);
                     wx_api_util.send_plan_status_msg(await util_lib.get_single_plan_by_id(new_plan.id));
+                    if (stuff.use_for_buy && stuff.auto_confirm_order) {
+                        await plan_lib.confirm_single_plan(new_plan.id, token, true);
+                    }
                 }
                 else {
                     throw { err_msg: '创建计划失败' };

--- a/api/module/stuff_module.js
+++ b/api/module/stuff_module.js
@@ -120,6 +120,7 @@ module.exports = {
                 comment: { type: String, have_to: false, mean: '备注', example: '备注' },
                 expect_count: { type: Number, have_to: false, mean: '预期数量', example: 1 },
                 use_for_buy: { type: Boolean, have_to: false, mean: '用于采购', example: false },
+                auto_confirm_order: { type: Boolean, have_to: false, mean: '自动确认订单', example: false },
                 close_time: { type: String, have_to: false, mean: '关闭时间', example: '12:00:00' },
                 delay_days: { type: Number, have_to: false, mean: '延迟天数', example: 1 },
                 concern_fapiao: { type: Boolean, have_to: false, mean: '关注发票', example: false },
@@ -135,6 +136,7 @@ module.exports = {
                 change_last_minutes: { type: Number, mean: '调价所剩分钟', example: 23 },
                 expect_count: { type: Number, mean: '期望单车装载量', example: 1 },
                 use_for_buy: { type: Boolean, mean: '用于采购', example: false },
+                auto_confirm_order: { type: Boolean, mean: '自动确认订单', example: false },
                 close_time: { type: String, mean: '关闭时间', example: '12:00:00' },
                 delay_days: { type: Number, mean: '延迟天数', example: 1 },
                 concern_fapiao: { type: Boolean, mean: '关注发票', example: false },
@@ -143,7 +145,7 @@ module.exports = {
             },
             func: async function (body, token) {
                 let company = await resolve_stuff_scope_company(token, body.stat_context_company_id, true);
-                return await plan_lib.fetch_stuff(body.name, body.comment, company, body.expect_count, body.use_for_buy, body.close_time, body.delay_days, body.concern_fapiao, body.stuff_code, body.close_today);
+                return await plan_lib.fetch_stuff(body.name, body.comment, company, body.expect_count, body.use_for_buy, body.close_time, body.delay_days, body.concern_fapiao, body.stuff_code, body.close_today, body.auto_confirm_order);
             }
         },
         get_all: {
@@ -165,6 +167,7 @@ module.exports = {
                         change_last_minutes: { type: Number, mean: '调价所剩分钟', example: 23 },
                         expect_count: { type: Number, mean: '期望单车装载量', example: 1 },
                         use_for_buy: { type: Boolean, mean: '用于采购', example: false },
+                        auto_confirm_order: { type: Boolean, mean: '自动确认订单', example: false },
                         need_sc: { type: Boolean, mean: '是否需要安检', example: false },
                         need_enter_weight: { type: Boolean, mean: '是否需要入场前重量', example: false },
                         no_need_register: { type: Boolean, mean: '是否不需要登记', example: false },

--- a/api/module/supplier_module.js
+++ b/api/module/supplier_module.js
@@ -117,7 +117,7 @@ module.exports = {
                     await new_plan.save();
                     plan_lib.mark_dup_info(new_plan.id);
                     wx_api_util.send_plan_status_msg(await util_lib.get_single_plan_by_id(new_plan.id));
-                    if (!stuff.need_enter_weight && stuff.no_need_register && !stuff.need_sc) {
+                    if (stuff.auto_confirm_order || (!stuff.need_enter_weight && stuff.no_need_register && !stuff.need_sc)) {
                         await plan_lib.confirm_single_plan(new_plan.id, token, true)
                     }
                 }

--- a/automation/stuff/plan_standard.robot
+++ b/automation/stuff/plan_standard.robot
@@ -28,6 +28,30 @@ Order Confirm
     Confirm A Order  ${plan}
     Search And Verify Order  ${mv}  ${bv}  ${dv}  ${plan}[id]  1
     Search By Plate Or Id    ${sc_admin_token}    ${mv}[plate]    ${dv}[id_card]    ${True}
+
+Order Auto Confirm With Config
+    [Teardown]  Run Keywords  Set Stuff Auto Confirm Order  ${order_stuff}[id]  ${False}  AND  Plan Reset
+    Set Stuff Auto Confirm Order  ${order_stuff}[id]  ${True}
+    ${mv}  Search Main Vehicle by Index  0
+    ${bv}  Search behind Vehicle by Index  0
+    ${dv}  Search Driver by Index  0
+    ${order}  Create A Order  ${bv}[id]  ${mv}[id]  ${dv}[id]
+    Should Not Be Equal As Integers  ${order}[status]  0
+    Set Stuff Auto Confirm Order  ${order_stuff}[id]  ${False}
+    ${order2}  Create A Order  ${bv}[id]  ${mv}[id]  ${dv}[id]
+    Should Be Equal As Integers  ${order2}[status]  0
+
+Plan Auto Confirm With Buy Stuff Config
+    [Teardown]  Run Keywords  Set Stuff Auto Confirm Order  ${order_stuff}[id]  ${False}  AND  Plan Reset
+    Set Stuff Auto Confirm Order  ${order_stuff}[id]  ${True}
+    ${mv}  Search Main Vehicle by Index  0
+    ${bv}  Search behind Vehicle by Index  0
+    ${dv}  Search Driver by Index  0
+    ${plan}  Create A Plan  ${bv}[id]  ${mv}[id]  ${dv}[id]  stuff_id=${order_stuff}[id]
+    Should Not Be Equal As Integers  ${plan}[status]  0
+    Set Stuff Auto Confirm Order  ${order_stuff}[id]  ${False}
+    ${plan2}  Create A Plan  ${bv}[id]  ${mv}[id]  ${dv}[id]  stuff_id=${order_stuff}[id]
+    Should Be Equal As Integers  ${plan2}[status]  0
 Plan Confirm with No Cash and Check
     [Teardown]  Plan Reset
     ${mv}  Search Main Vehicle by Index  0

--- a/automation/stuff/stuff_curd.robot
+++ b/automation/stuff/stuff_curd.robot
@@ -62,6 +62,21 @@ Stuff For Buy
     @{stuffs_found}  Req Get to Server  /supplier/get_stuff_need_buy  ${bc1_user_token}  stuff
     Length Should Be  ${stuffs_found}  1
 
+Buy Stuff Auto Confirm Order Config
+    [Teardown]  Run Keywords  Contract Reset  AND  Stuff Reset
+    Add A Company As Supplier  ${buy_company1}[id]
+    ${buy_stuff}  Add A Stuff To Buy  aco1  aco1_comment
+    Should Be Equal  ${buy_stuff}[use_for_buy]  ${True}
+    Should Be Equal  ${buy_stuff}[auto_confirm_order]  ${False}
+    ${stuff}  Get Stuff By Id  ${buy_stuff}[id]
+    Should Be Equal  ${stuff}[auto_confirm_order]  ${False}
+    Set Stuff Auto Confirm Order  ${buy_stuff}[id]  ${True}
+    ${stuff}  Get Stuff By Id  ${buy_stuff}[id]
+    Should Be Equal  ${stuff}[auto_confirm_order]  ${True}
+    Set Stuff Auto Confirm Order  ${buy_stuff}[id]  ${False}
+    ${stuff}  Get Stuff By Id  ${buy_stuff}[id]
+    Should Be Equal  ${stuff}[auto_confirm_order]  ${False}
+
 
 Stuff via Contract Maintain
     [Teardown]  Run Keywords  Contract Reset  AND  Stuff Reset

--- a/automation/stuff/stuff_opt.resource
+++ b/automation/stuff/stuff_opt.resource
@@ -638,6 +638,12 @@ Set Auto Confirm Goods
     [Arguments]  ${stuff_id}=${test_stuff}[id]  ${token}=${sc_admin_token}  ${auto_confirm_goods}=${True}
     ${req}  Create Dictionary  stuff_id=${stuff_id}  auto_confirm_goods=${auto_confirm_goods}
     Req to Server  /stuff/auto_confirm_goods  ${token}  ${req}
+Set Stuff Auto Confirm Order
+    [Arguments]  ${stuff_id}  ${auto_confirm_order}=${True}  ${token}=${sc_admin_token}
+    ${stuff}  Get Stuff By Id  ${stuff_id}  ${token}
+    Set To Dictionary  ${stuff}  auto_confirm_order=${auto_confirm_order}
+    ${resp}  Req to Server  /stuff/fetch  ${token}  ${stuff}
+    RETURN  ${resp}
 Input Plan Sct Info
     [Arguments]  ${plan_id}  ${psi_id}  ${value}  ${token}=${sc_admin_token}
     ${req}  Create Dictionary  plan_id=${plan_id}  psi_id=${psi_id}  value=${value}

--- a/mt_gui/src/subPage1/Stuff.vue
+++ b/mt_gui/src/subPage1/Stuff.vue
@@ -308,7 +308,13 @@
             </fui-input>
             <fui-date-picker :show="show_close_time" type="6" @change="choose_time" @cancel="show_close_time = false"></fui-date-picker>
             <fui-form-item label="用于采购">
-                <u-switch v-model="stuff_ready_fetch.use_for_buy"></u-switch>
+                <view style="display: flex; align-items: center; gap: 20rpx;">
+                    <u-switch v-model="stuff_ready_fetch.use_for_buy" @change="on_use_for_buy_change"></u-switch>
+                    <view v-if="stuff_ready_fetch.use_for_buy" style="display: flex; align-items: center; gap: 10rpx;">
+                        <fui-text size="28" text="自动确认订单"></fui-text>
+                        <u-switch v-model="stuff_ready_fetch.auto_confirm_order"></u-switch>
+                    </view>
+                </view>
             </fui-form-item>
             <fui-form-item label="关注发票">
                 <u-switch v-model="stuff_ready_fetch.concern_fapiao"></u-switch>
@@ -415,6 +421,7 @@ export default {
                 comment: undefined,
                 expect_count: undefined,
                 use_for_buy: false,
+                auto_confirm_order: false,
                 close_time: '',
                 delay_days: 0,
                 concern_fapiao: false,
@@ -939,6 +946,11 @@ export default {
             this.item_for_delete = item;
             this.show_delete = true;
         },
+        on_use_for_buy_change: function (event) {
+            if (!event.detail.value) {
+                this.stuff_ready_fetch.auto_confirm_order = false;
+            }
+        },
         prepare_update: function (item) {
             if (item.delay_days == null) {
                 item.delay_days = 0;
@@ -948,6 +960,7 @@ export default {
                 comment: item.comment,
                 expect_count: item.expect_count,
                 use_for_buy: item.use_for_buy,
+                auto_confirm_order: item.auto_confirm_order || false,
                 close_time: item.close_time,
                 delay_days: item.delay_days,
                 concern_fapiao: item.concern_fapiao,
@@ -1128,6 +1141,7 @@ export default {
             comment: undefined,
             expect_count: undefined,
             use_for_buy: false,
+            auto_confirm_order: false,
             close_time: '',
             delay_days: 0,
             concern_fapiao: false,

--- a/mt_pc/src/views/stuff/StuffConfig.vue
+++ b/mt_pc/src/views/stuff/StuffConfig.vue
@@ -190,7 +190,8 @@
                     <el-switch v-model="stuff_ready_fetch.close_today" active-text="关闭当日" inactive-text="关闭前日"></el-switch>
                 </el-form-item>
                 <el-form-item label="用于采购" prop="use_for_buy">
-                    <el-switch v-model="stuff_ready_fetch.use_for_buy"></el-switch>
+                    <el-switch v-model="stuff_ready_fetch.use_for_buy" @change="on_use_for_buy_change"></el-switch>
+                    <el-switch v-if="stuff_ready_fetch.use_for_buy" v-model="stuff_ready_fetch.auto_confirm_order" active-text="自动确认订单" style="margin-left: 20px;"></el-switch>
                 </el-form-item>
                 <el-form-item label="关注发票" prop="concern_fapiao">
                     <el-switch v-model="stuff_ready_fetch.concern_fapiao"></el-switch>
@@ -339,6 +340,7 @@ export default {
                 comment: undefined,
                 expect_count: undefined,
                 use_for_buy: false,
+                auto_confirm_order: false,
                 close_time: '',
                 delay_days: 0,
                 concern_fapiao: false,
@@ -786,6 +788,11 @@ export default {
                 this.$refs.form.resetFields();
             }
         },
+        on_use_for_buy_change: function (val) {
+            if (!val) {
+                this.stuff_ready_fetch.auto_confirm_order = false;
+            }
+        },
         prepare_update: function (item) {
             if (item.delay_days == null) {
                 item.delay_days = 0;
@@ -795,6 +802,7 @@ export default {
                 comment: item.comment,
                 expect_count: item.expect_count,
                 use_for_buy: item.use_for_buy,
+                auto_confirm_order: item.auto_confirm_order || false,
                 close_time: item.close_time ? new Date(`2000-01-01T${item.close_time}`) : null,
                 delay_days: item.delay_days,
                 concern_fapiao: item.concern_fapiao,


### PR DESCRIPTION
1.采购的物料可以自动确认
<img width="562" height="151" alt="image" src="https://github.com/user-attachments/assets/403f4001-aaa9-452b-ae41-ec3d030b6ec9" />
<img width="587" height="137" alt="image" src="https://github.com/user-attachments/assets/ae467cb3-8586-4ae8-a6ca-4c1fed562780" />
