### PR TITLE
ZYZL-709-增加基于合同-物料二元组的优惠方案应用

### DIFF
--- a/api/db_opt.js
+++ b/api/db_opt.js
@@ -155,6 +155,9 @@ let db_opt = {
             id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
             unit_price: { type: DataTypes.DECIMAL(12, 2), defaultValue: 0, get: getDecimalValue('unit_price') },
         },
+        contract_stuff_scheme: {
+            id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+        },
         plan: {
             id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
             plan_time: { type: DataTypes.STRING },
@@ -551,6 +554,19 @@ let db_opt = {
         _sq.models.contract.hasMany(_sq.models.contract_stuff_price);
         _sq.models.contract_stuff_price.belongsTo(_sq.models.stuff);
         _sq.models.stuff.hasMany(_sq.models.contract_stuff_price);
+        _sq.models.contract_stuff_scheme.belongsTo(_sq.models.contract);
+        _sq.models.contract.hasMany(_sq.models.contract_stuff_scheme);
+        _sq.models.contract_stuff_scheme.belongsTo(_sq.models.stuff);
+        _sq.models.stuff.hasMany(_sq.models.contract_stuff_scheme);
+        _sq.models.contract_stuff_scheme.belongsTo(_sq.models.contract_discount_scheme, {
+            as: 'discount_scheme',
+            foreignKey: 'discountSchemeId',
+            constraints: false,
+        });
+        _sq.models.contract_discount_scheme.hasMany(_sq.models.contract_stuff_scheme, {
+            foreignKey: 'discountSchemeId',
+            constraints: false,
+        });
         _sq.models.balance_history.belongsTo(_sq.models.contract);
         _sq.models.contract.hasMany(_sq.models.balance_history);
         _sq.models.price_history.belongsTo(_sq.models.stuff);

--- a/api/lib/plan_lib.js
+++ b/api/lib/plan_lib.js
@@ -507,6 +507,7 @@ module.exports = {
             item.expired = this.contractOutOfDate(item.end_time);
         });
         let price_map = new Map();
+        let scheme_map = new Map();
         if (rows.length > 0) {
             const contract_ids = rows.map(item => item.id);
             const price_rows = await sq.models.contract_stuff_price.findAll({
@@ -515,7 +516,7 @@ module.exports = {
                         [db_opt.Op.in]: contract_ids
                     }
                 },
-                include: [{ model: sq.models.stuff, attributes: ['id', 'name'] }],
+                include: [{ model: sq.models.stuff, attributes: ['id', 'name'], include: [{ model: sq.models.company, attributes: ['id', 'name'] }] }],
                 order: [['id', 'ASC']],
             });
             price_rows.forEach((row) => {
@@ -525,12 +526,32 @@ module.exports = {
                 }
                 price_map.get(cid).push(typeof row.toJSON === 'function' ? row.toJSON() : row);
             });
+            const scheme_rows = await sq.models.contract_stuff_scheme.findAll({
+                where: {
+                    contractId: {
+                        [db_opt.Op.in]: contract_ids
+                    }
+                },
+                include: [
+                    { model: sq.models.stuff, attributes: ['id', 'name'], include: [{ model: sq.models.company, attributes: ['id', 'name'] }] },
+                    { model: sq.models.contract_discount_scheme, as: 'discount_scheme' },
+                ],
+                order: [['id', 'ASC']],
+            });
+            scheme_rows.forEach((row) => {
+                const cid = row.contractId;
+                if (!scheme_map.has(cid)) {
+                    scheme_map.set(cid, []);
+                }
+                scheme_map.get(cid).push(typeof row.toJSON === 'function' ? row.toJSON() : row);
+            });
         }
         const plain_rows = rows.map((item) => {
             const one = typeof item.toJSON === 'function' ? item.toJSON() : { ...item };
             one.company = one.buy_company || one.company;
             one.expired = this.contractOutOfDate(one.end_time);
             one.contract_stuff_prices = price_map.get(one.id) || [];
+            one.contract_stuff_schemes = scheme_map.get(one.id) || [];
             return one;
         });
         return { rows: plain_rows, count: count };
@@ -544,14 +565,41 @@ module.exports = {
             }
         });
     },
+    get_contract_stuff_scheme: async function (contract_id, stuff_id) {
+        const sq = db_opt.get_sq();
+        return await sq.models.contract_stuff_scheme.findOne({
+            where: {
+                contractId: contract_id,
+                stuffId: stuff_id,
+            },
+            include: [{ model: sq.models.contract_discount_scheme, as: 'discount_scheme' }],
+        });
+    },
+    get_contract_discount_scheme_for_stuff: async function (contract, stuff_id) {
+        const stuff_scheme = await this.get_contract_stuff_scheme(contract.id, stuff_id);
+        if (stuff_scheme) {
+            let scheme = stuff_scheme.discount_scheme;
+            if (!scheme && stuff_scheme.discountSchemeId) {
+                const sq = db_opt.get_sq();
+                scheme = await sq.models.contract_discount_scheme.findByPk(stuff_scheme.discountSchemeId);
+            }
+            if (scheme) {
+                return scheme;
+            }
+        }
+        if (contract.discountSchemeId) {
+            const sq = db_opt.get_sq();
+            return await sq.models.contract_discount_scheme.findByPk(contract.discountSchemeId);
+        }
+        return null;
+    },
     get_contract_effective_unit_price: async function (contract, stuff, default_price) {
         let final_price = default_price;
         const override_price = await this.get_contract_stuff_price(contract.id, stuff.id);
         if (override_price) {
             final_price = override_price.unit_price;
-        } else if (contract.discountSchemeId) {
-            const sq = db_opt.get_sq();
-            const scheme = await sq.models.contract_discount_scheme.findByPk(contract.discountSchemeId);
+        } else {
+            const scheme = await this.get_contract_discount_scheme_for_stuff(contract, stuff.id);
             if (scheme) {
                 final_price = Number(default_price) + Number(scheme.delta_price);
             }
@@ -1785,8 +1833,8 @@ module.exports = {
                         const override_price = await this.get_contract_stuff_price(picked_contract.id, stuff.id);
                         if (override_price) {
                             should_skip_update = true;
-                        } else if (picked_contract.discountSchemeId) {
-                            const scheme = await sq.models.contract_discount_scheme.findByPk(picked_contract.discountSchemeId);
+                        } else {
+                            const scheme = await this.get_contract_discount_scheme_for_stuff(picked_contract, stuff.id);
                             if (scheme) {
                                 target_unit_price = Number((Number(_new_price) + Number(scheme.delta_price)).toFixed(2));
                             }

--- a/api/module/sale_management_module.js
+++ b/api/module/sale_management_module.js
@@ -45,6 +45,11 @@ function prefix_contract_stuff_in_contracts(contracts, home_company) {
                 prefix_contract_stuff_names([price.stuff], home_company);
             }
         });
+        (contract.contract_stuff_schemes || []).forEach((scheme_row) => {
+            if (scheme_row.stuff) {
+                prefix_contract_stuff_names([scheme_row.stuff], home_company);
+            }
+        });
     });
 }
 
@@ -569,6 +574,27 @@ module.exports = {
                                 },
                             }
                         },
+                        contract_stuff_schemes: {
+                            type: Array, mean: '合同物料优惠方案', explain: {
+                                id: { type: Number, mean: 'ID', example: 1 },
+                                contractId: { type: Number, mean: '合同ID', example: 1 },
+                                stuffId: { type: Number, mean: '物料ID', example: 1 },
+                                discountSchemeId: { type: Number, mean: '优惠方案ID', example: 1 },
+                                stuff: {
+                                    type: Object, mean: '物料信息', explain: {
+                                        id: { type: Number, mean: '物料ID', example: 1 },
+                                        name: { type: String, mean: '物料名', example: 'LNG' },
+                                    }
+                                },
+                                discount_scheme: {
+                                    type: Object, mean: '优惠方案', explain: {
+                                        id: { type: Number, mean: '方案ID', example: 1 },
+                                        name: { type: String, mean: '方案名', example: '单价-1元' },
+                                        delta_price: { type: Number, mean: '单价调整值', example: -1 },
+                                    }
+                                },
+                            }
+                        },
                     }
                 }
             },
@@ -753,6 +779,7 @@ module.exports = {
                     throw { err_msg: '无权限' };
                 }
                 await sq.models.contract.update({ discountSchemeId: null }, { where: { discountSchemeId: item.id } });
+                await sq.models.contract_stuff_scheme.destroy({ where: { discountSchemeId: item.id } });
                 await item.destroy();
                 return { result: true };
             },
@@ -764,6 +791,7 @@ module.exports = {
             is_get_api: false,
             params: {
                 contract_id: { type: Number, have_to: true, mean: '合同ID', example: 1 },
+                stuff_id: { type: Number, have_to: false, mean: '优惠物料ID，不传则应用于合同全部关联物料', example: 1 },
                 scheme_id: { type: Number, have_to: false, mean: '优惠方案ID，空表示取消', example: 1 },
                 stat_context_company_id: { type: Number, have_to: false, mean: '集团场景操作主体公司id', example: 1 },
             },
@@ -778,16 +806,50 @@ module.exports = {
                 if (!contract || !(await plan_lib.has_sale_contract_operate_permission(company, contract))) {
                     throw { err_msg: '无权限' };
                 }
-                if (body.scheme_id) {
-                    const scheme = await sq.models.contract_discount_scheme.findByPk(body.scheme_id);
+                const upsert_stuff_scheme = async function (stuff_id, scheme_id) {
+                    const where = { contractId: contract.id, stuffId: stuff_id };
+                    const exist_row = await sq.models.contract_stuff_scheme.findOne({ where });
+                    if (!scheme_id) {
+                        if (exist_row) {
+                            await exist_row.destroy();
+                        }
+                        return;
+                    }
+                    const scheme = await sq.models.contract_discount_scheme.findByPk(scheme_id);
                     if (!scheme || scheme.companyId !== owner_company_id) {
                         throw { err_msg: '优惠方案不存在' };
                     }
-                    contract.discountSchemeId = scheme.id;
+                    if (exist_row) {
+                        exist_row.discountSchemeId = scheme.id;
+                        await exist_row.save();
+                    } else {
+                        await sq.models.contract_stuff_scheme.create({
+                            ...where,
+                            discountSchemeId: scheme.id,
+                        });
+                    }
+                };
+                if (body.stuff_id) {
+                    const { stuff, can_operate } = await resolve_contract_stuff_operate_context(token, body);
+                    if (!can_operate || !stuff) {
+                        throw { err_msg: '无权限' };
+                    }
+                    if (!(await contract.hasStuff(stuff))) {
+                        throw { err_msg: '该合同未关联此物料' };
+                    }
+                    await upsert_stuff_scheme(stuff.id, body.scheme_id || null);
                 } else {
+                    const stuff_list = await contract.getStuff();
+                    if (!body.scheme_id) {
+                        await sq.models.contract_stuff_scheme.destroy({ where: { contractId: contract.id } });
+                    } else {
+                        for (let i = 0; i < stuff_list.length; i++) {
+                            await upsert_stuff_scheme(stuff_list[i].id, body.scheme_id);
+                        }
+                    }
                     contract.discountSchemeId = null;
+                    await contract.save();
                 }
-                await contract.save();
                 return { result: true };
             },
         },

--- a/automation/group/group_contract_price_strategy.robot
+++ b/automation/group/group_contract_price_strategy.robot
@@ -19,6 +19,7 @@ Group Contract Price Suite Reset
     Company Reset
     Clear Table  contract_discount_scheme
     Clear Table  contract_stuff_price
+    Clear Table  contract_stuff_scheme
 
 Setup Group Contract Price Scenario
     [Arguments]  ${can_operate}=${True}
@@ -138,6 +139,99 @@ Get Buyer Plan By Id
     END
     Should Not Be Empty  ${found_plan}
     RETURN  ${found_plan}
+
+Setup Group Contract Price Scenario With Two Stuff
+    [Arguments]  ${can_operate}=${True}
+    ${suffix}  Evaluate  random.randint(100000, 999999)  modules=random
+    ${parent_name}  Set Variable  gcp_parent_${suffix}
+    ${member_name}  Set Variable  gcp_member_${suffix}
+    ${buyer_name}  Set Variable  gcp_buyer_${suffix}
+    ${phone_tail}  Evaluate  random.randint(100, 999)  modules=random
+    ${parent_phone}  Set Variable  16710000${phone_tail}
+    ${member_phone}  Set Variable  16720000${phone_tail}
+    ${buyer_phone}  Set Variable  16730000${phone_tail}
+
+    ${parent}  Create One Company  ${parent_name}
+    ${member}  Create One Company  ${member_name}
+    ${buyer}  Create One Company  ${buyer_name}
+
+    ${parent_token}  Login As Admin Of Company  ${parent}[id]  ${parent_phone}  gcp_parent_admin_${suffix}
+    ${member_token}  Login As Admin Of Company  ${member}[id]  ${member_phone}  gcp_member_admin_${suffix}
+    ${buyer_token}  Login As Admin Of Company  ${buyer}[id]  ${buyer_phone}  gcp_buyer_admin_${suffix}
+
+    ${parent_self}  Get Self Info  ${parent_token}
+    Convert To Group By Super Admin  ${parent}[id]  ${parent_self}[id]
+    ${add_member_req}  Create Dictionary  member_company_id=${member}[id]
+    Req to Server  /group/group_member_add  ${parent_token}  ${add_member_req}
+    Group Grant Upsert Self On Member  ${parent_token}  ${member}[id]  ${parent_self}[id]  ${True}  ${can_operate}
+    Assert Group Grant Can Operate  ${parent_token}  ${member}[id]  ${parent_self}[id]  ${can_operate}
+
+    Add Module To Company  ${parent}[id]  sale_management
+    Add Module To User  ${parent_token}  ${parent_phone}  sale_management
+    Add Module To Company  ${member}[id]  stuff
+    Add Module To User  ${member_token}  ${member_phone}  stuff
+    Add Module To Company  ${buyer}[id]  customer
+    Add Module To User  ${buyer_token}  ${buyer_phone}  customer
+
+    ${new_stuff_req_a}  Create Dictionary  name=gcp_member_stuff_a_${suffix}  comment=member_source_a  expect_count=${2}
+    ${member_stuff_a}  Req to Server  /stuff/fetch  ${member_token}  ${new_stuff_req_a}
+    ${new_stuff_req_b}  Create Dictionary  name=gcp_member_stuff_b_${suffix}  comment=member_source_b  expect_count=${2}
+    ${member_stuff_b}  Req to Server  /stuff/fetch  ${member_token}  ${new_stuff_req_b}
+    ${price_req_a}  Create Dictionary  stuff_id=${member_stuff_a}[id]  price=${100}  to_plan=${False}  comment=group_contract_price_test_a
+    Req to Server  /stuff/change_price  ${member_token}  ${price_req_a}
+    ${price_req_b}  Create Dictionary  stuff_id=${member_stuff_b}[id]  price=${100}  to_plan=${False}  comment=group_contract_price_test_b
+    Req to Server  /stuff/change_price  ${member_token}  ${price_req_b}
+
+    ${new_contract_req}  Create Dictionary  customer_id=${buyer}[id]
+    Req to Server  /sale_management/contract_make  ${parent_token}  ${new_contract_req}
+    ${contract}  Req to Server  /sale_management/get_contract_by_customer  ${parent_token}  ${new_contract_req}
+    ${contract_stuff_req_a}  Create Dictionary  contract_id=${contract}[id]  stuff_id=${member_stuff_a}[id]
+    Req to Server  /sale_management/contract_add_stuff  ${parent_token}  ${contract_stuff_req_a}
+    ${contract_stuff_req_b}  Create Dictionary  contract_id=${contract}[id]  stuff_id=${member_stuff_b}[id]
+    Req to Server  /sale_management/contract_add_stuff  ${parent_token}  ${contract_stuff_req_b}
+
+    Set Suite Variable  ${PARENT_TOKEN}  ${parent_token}
+    Set Suite Variable  ${BUYER_TOKEN}  ${buyer_token}
+    Set Suite Variable  ${MEMBER_TOKEN}  ${member_token}
+    Set Suite Variable  ${MEMBER_COMPANY}  ${member}
+    Set Suite Variable  ${MEMBER_STUFF_A}  ${member_stuff_a}
+    Set Suite Variable  ${MEMBER_STUFF_B}  ${member_stuff_b}
+    Set Suite Variable  ${CONTRACT}  ${contract}
+
+Create Buyer Plan With Stuff Id
+    [Arguments]  ${stuff_id}  ${idx}=0
+    ${driver_phone}  Evaluate  16790000 + ${idx}
+    ${driver_phone}  Convert To String  ${driver_phone}
+    ${driver_req}  Create Dictionary  name=gcp_driver_${idx}  phone=${driver_phone}
+    ${driver}  Req to Server  /customer/fetch_driver  ${BUYER_TOKEN}  ${driver_req}
+    ${main_plate}  Set Variable  京GCP${idx}1
+    ${behind_plate}  Set Variable  京GCP${idx}2
+    ${main_req}  Create Dictionary  plate=${main_plate}
+    ${behind_req}  Create Dictionary  plate=${behind_plate}
+    ${main_vehicle}  Req to Server  /customer/fetch_vehicle  ${BUYER_TOKEN}  ${main_req}
+    ${behind_vehicle}  Req to Server  /customer/fetch_vehicle  ${BUYER_TOKEN}  ${behind_req}
+    ${today}  Get Current Date  result_format=%Y-%m-%d
+    ${create_req}  Create Dictionary
+    ...  plan_time=${today}
+    ...  use_for=group-contract-price-test
+    ...  drop_address=test-addr
+    ...  stuff_id=${stuff_id}
+    ...  main_vehicle_id=${main_vehicle}[id]
+    ...  behind_vehicle_id=${behind_vehicle}[id]
+    ...  driver_id=${driver}[id]
+    ${plan}  Req to Server  /customer/order_buy_create  ${BUYER_TOKEN}  ${create_req}
+    RETURN  ${plan}
+
+Get Sale Contract By Id
+    [Arguments]  ${token}  ${contract_id}  ${member_company_id}
+    ${req}  Create Dictionary  stat_context_company_id=${member_company_id}
+    ${contracts}  Req Get to Server  /sale_management/contract_get  ${token}  contracts  ${-1}  &{req}
+    FOR  ${c}  IN  @{contracts}
+        IF  ${c}[id] == ${contract_id}
+            RETURN  ${c}
+        END
+    END
+    Fail  未找到合同 ${contract_id}
 
 *** Test Cases ***
 Group CanOperate User Can Set Scheme And Stuff Override Price
@@ -260,6 +354,99 @@ Stuff Change Price ToPlan Uses New Price Without Contract Strategy
 
     ${plan_after}  Get Buyer Plan By Id  ${BUYER_TOKEN}  ${plan}[id]
     Should Be Equal As Numbers  ${plan_after}[unit_price]  109
+
+Contract Set Scheme For All Linked Stuff Writes Per Stuff Schemes
+    [Setup]  Setup Group Contract Price Scenario  ${True}
+    ${save_scheme_req}  Create Dictionary
+    ...  name=全部物料优惠
+    ...  delta_price=${-1.6}
+    ...  stat_context_company_id=${MEMBER_COMPANY}[id]
+    Req to Server  /sale_management/discount_scheme_upsert  ${PARENT_TOKEN}  ${save_scheme_req}
+    ${scheme_id}  Find Discount Scheme Id By Name  ${PARENT_TOKEN}  ${MEMBER_COMPANY}[id]  全部物料优惠
+
+    ${set_scheme_req}  Create Dictionary
+    ...  contract_id=${CONTRACT}[id]
+    ...  scheme_id=${scheme_id}
+    ...  stat_context_company_id=${MEMBER_COMPANY}[id]
+    Req to Server  /sale_management/contract_set_discount_scheme  ${PARENT_TOKEN}  ${set_scheme_req}
+
+    ${contract_detail}  Get Sale Contract By Id  ${PARENT_TOKEN}  ${CONTRACT}[id]  ${MEMBER_COMPANY}[id]
+    ${scheme_rows}  Get From Dictionary  ${contract_detail}  contract_stuff_schemes
+    ${row_count}  Get Length  ${scheme_rows}
+    Should Be Equal As Integers  ${row_count}  ${1}
+    Should Be Equal As Integers  ${scheme_rows}[0][stuffId]  ${MEMBER_STUFF}[id]
+    Should Be Equal As Integers  ${scheme_rows}[0][discountSchemeId]  ${scheme_id}
+
+    ${plan}  Create Buyer Plan With Member Stuff  ${31}
+    Should Be Equal As Numbers  ${plan}[unit_price]  98.4
+
+Per Stuff Scheme Overrides All Stuff Default
+    [Setup]  Setup Group Contract Price Scenario With Two Stuff  ${True}
+    ${save_mild_req}  Create Dictionary
+    ...  name=温和优惠
+    ...  delta_price=${-1.6}
+    ...  stat_context_company_id=${MEMBER_COMPANY}[id]
+    Req to Server  /sale_management/discount_scheme_upsert  ${PARENT_TOKEN}  ${save_mild_req}
+    ${mild_scheme_id}  Find Discount Scheme Id By Name  ${PARENT_TOKEN}  ${MEMBER_COMPANY}[id]  温和优惠
+
+    ${save_strong_req}  Create Dictionary
+    ...  name=强力优惠
+    ...  delta_price=${-3}
+    ...  stat_context_company_id=${MEMBER_COMPANY}[id]
+    Req to Server  /sale_management/discount_scheme_upsert  ${PARENT_TOKEN}  ${save_strong_req}
+    ${strong_scheme_id}  Find Discount Scheme Id By Name  ${PARENT_TOKEN}  ${MEMBER_COMPANY}[id]  强力优惠
+
+    ${set_all_scheme_req}  Create Dictionary
+    ...  contract_id=${CONTRACT}[id]
+    ...  scheme_id=${mild_scheme_id}
+    ...  stat_context_company_id=${MEMBER_COMPANY}[id]
+    Req to Server  /sale_management/contract_set_discount_scheme  ${PARENT_TOKEN}  ${set_all_scheme_req}
+
+    ${set_stuff_a_scheme_req}  Create Dictionary
+    ...  contract_id=${CONTRACT}[id]
+    ...  stuff_id=${MEMBER_STUFF_A}[id]
+    ...  scheme_id=${strong_scheme_id}
+    ...  stat_context_company_id=${MEMBER_COMPANY}[id]
+    Req to Server  /sale_management/contract_set_discount_scheme  ${PARENT_TOKEN}  ${set_stuff_a_scheme_req}
+
+    ${plan_a}  Create Buyer Plan With Stuff Id  ${MEMBER_STUFF_A}[id]  ${32}
+    Should Be Equal As Numbers  ${plan_a}[unit_price]  97
+    ${plan_b}  Create Buyer Plan With Stuff Id  ${MEMBER_STUFF_B}[id]  ${33}
+    Should Be Equal As Numbers  ${plan_b}[unit_price]  98.4
+
+Clear Per Stuff Scheme Uses Base Price
+    [Setup]  Setup Group Contract Price Scenario  ${True}
+    ${save_scheme_req}  Create Dictionary
+    ...  name=可清空优惠
+    ...  delta_price=${-2}
+    ...  stat_context_company_id=${MEMBER_COMPANY}[id]
+    Req to Server  /sale_management/discount_scheme_upsert  ${PARENT_TOKEN}  ${save_scheme_req}
+    ${scheme_id}  Find Discount Scheme Id By Name  ${PARENT_TOKEN}  ${MEMBER_COMPANY}[id]  可清空优惠
+
+    ${set_scheme_req}  Create Dictionary
+    ...  contract_id=${CONTRACT}[id]
+    ...  stuff_id=${MEMBER_STUFF}[id]
+    ...  scheme_id=${scheme_id}
+    ...  stat_context_company_id=${MEMBER_COMPANY}[id]
+    Req to Server  /sale_management/contract_set_discount_scheme  ${PARENT_TOKEN}  ${set_scheme_req}
+
+    ${plan_with_scheme}  Create Buyer Plan With Member Stuff  ${34}
+    Should Be Equal As Numbers  ${plan_with_scheme}[unit_price]  98
+
+    ${clear_scheme_req}  Create Dictionary
+    ...  contract_id=${CONTRACT}[id]
+    ...  stuff_id=${MEMBER_STUFF}[id]
+    ...  scheme_id=${null}
+    ...  stat_context_company_id=${MEMBER_COMPANY}[id]
+    Req to Server  /sale_management/contract_set_discount_scheme  ${PARENT_TOKEN}  ${clear_scheme_req}
+
+    ${contract_detail}  Get Sale Contract By Id  ${PARENT_TOKEN}  ${CONTRACT}[id]  ${MEMBER_COMPANY}[id]
+    ${scheme_rows}  Get From Dictionary  ${contract_detail}  contract_stuff_schemes
+    ${row_count}  Get Length  ${scheme_rows}
+    Should Be Equal As Integers  ${row_count}  ${0}
+
+    ${plan_without_scheme}  Create Buyer Plan With Member Stuff  ${35}
+    Should Be Equal As Numbers  ${plan_without_scheme}[unit_price]  100
 
 Group ViewOnly User Cannot Configure Member Company Price Strategy
     [Setup]  Setup Group Contract Price Scenario  ${False}

--- a/mt_gui/src/subPage1/Contract.vue
+++ b/mt_gui/src/subPage1/Contract.vue
@@ -39,8 +39,20 @@
                     <view v-if="item.begin_time && item.end_time" style="color: blue;">
                         {{item.begin_time}}至{{item.end_time}}
                     </view>
-                    <view v-if="show_scope_switch" style="color: #8a2be2;">
-                        优惠方案: {{item.discount_scheme ? item.discount_scheme.name : '无'}}
+                    <view v-if="show_scope_switch" style="display:flex; flex-wrap: wrap; gap: 8rpx;">
+                        <template v-if="item.contract_stuff_schemes && item.contract_stuff_schemes.length > 0">
+                            <fui-tag
+                                v-for="scheme_row in item.contract_stuff_schemes"
+                                :key="scheme_row.id || (scheme_row.stuffId + '-' + scheme_row.discountSchemeId)"
+                                :scaleRatio="0.8"
+                                originLeft
+                                type="primary"
+                                :text="format_scheme_tag_text(scheme_row)"
+                            ></fui-tag>
+                        </template>
+                        <view v-else style="color: #8a2be2;">
+                            优惠方案: {{item.discount_scheme ? item.discount_scheme.name : '无'}}
+                        </view>
                     </view>
                     <view v-if="item.number" style="color: green;">
                         合同编号: {{item.number}}
@@ -169,6 +181,16 @@
     </fui-modal>
     <fui-modal width="600" :descr="'确定删除优惠方案' + focus_scheme.name + '吗？'" :show="show_delete_scheme" v-if="show_delete_scheme" @click="delete_scheme">
     </fui-modal>
+    <fui-bottom-popup :show="show_contract_scheme_stuff_popup" @close="show_contract_scheme_stuff_popup = false">
+        <fui-list>
+            <fui-list-cell arrow @click="prepare_scheme_for_all_stuff">
+                全部关联物料（默认）（当前: {{get_all_stuff_scheme_text()}}）
+            </fui-list-cell>
+            <fui-list-cell v-for="(single_stuff, index) in (focus_item.stuff || [])" :key="single_stuff.id" :index="index" arrow @click="prepare_scheme_for_stuff_by_index">
+                {{single_stuff.name}}（当前: {{get_scheme_text_for_stuff(single_stuff.id)}}）
+            </fui-list-cell>
+        </fui-list>
+    </fui-bottom-popup>
     <fui-bottom-popup :show="show_contract_scheme_picker" @close="show_contract_scheme_picker = false">
         <fui-list>
             <fui-list-cell arrow @click="set_contract_scheme(null)">清空方案</fui-list-cell>
@@ -265,6 +287,8 @@ export default {
             },
             show_delete_scheme: false,
             show_contract_scheme_picker: false,
+            show_contract_scheme_stuff_popup: false,
+            focus_scheme_stuff: {},
             show_stuff_price_popup: false,
             show_stuff_price_modal: false,
             stuff_price_input: '',
@@ -397,13 +421,62 @@ export default {
         prepare_set_contract_scheme: async function (item) {
             this.focus_item = item;
             await this.load_discount_schemes();
+            this.show_contract_scheme_stuff_popup = true;
+        },
+        prepare_scheme_for_all_stuff: function () {
+            this.focus_scheme_stuff = null;
+            this.show_contract_scheme_stuff_popup = false;
             this.show_contract_scheme_picker = true;
         },
+        prepare_scheme_for_stuff_by_index: function (e) {
+            const index = e && typeof e.index === 'number' ? e.index : -1;
+            const single_stuff = ((this.focus_item && this.focus_item.stuff) || [])[index];
+            if (!single_stuff || !single_stuff.id) {
+                uni.showToast({ title: '未找到物料，请重试', icon: 'none' });
+                return;
+            }
+            this.focus_scheme_stuff = single_stuff;
+            this.show_contract_scheme_stuff_popup = false;
+            this.show_contract_scheme_picker = true;
+        },
+        get_all_stuff_scheme_text: function () {
+            const rows = (this.focus_item && this.focus_item.contract_stuff_schemes) || [];
+            if (rows.length > 0) {
+                const firstSchemeId = rows[0].discountSchemeId;
+                const allSame = rows.every((row) => row.discountSchemeId === firstSchemeId);
+                if (allSame && rows[0].discount_scheme) {
+                    return rows[0].discount_scheme.name;
+                }
+                if (allSame && !rows[0].discount_scheme) {
+                    return '无';
+                }
+                return '各物料不同';
+            }
+            return this.focus_item && this.focus_item.discount_scheme
+                ? this.focus_item.discount_scheme.name
+                : '无';
+        },
+        get_scheme_text_for_stuff: function (stuff_id) {
+            const rows = (this.focus_item && this.focus_item.contract_stuff_schemes) || [];
+            const found = rows.find((row) => row.stuffId === stuff_id);
+            return found && found.discount_scheme ? found.discount_scheme.name : '无';
+        },
+        format_scheme_tag_text: function (scheme_row) {
+            const stuff_name = scheme_row.stuff && scheme_row.stuff.name ? scheme_row.stuff.name : `物料#${scheme_row.stuffId}`;
+            const scheme_name = scheme_row.discount_scheme && scheme_row.discount_scheme.name
+                ? scheme_row.discount_scheme.name
+                : '无';
+            return `${stuff_name}: ${scheme_name}`;
+        },
         set_contract_scheme: async function (scheme_id) {
-            const req = this.make_context_req({
+            const req_body = {
                 contract_id: this.focus_item.id,
                 scheme_id: scheme_id,
-            }, '/sale_management/contract_set_discount_scheme', this.show_scope_switch, this.self_info && this.self_info.company_is_group === true, this.stat_context_company_id);
+            };
+            if (this.focus_scheme_stuff && this.focus_scheme_stuff.id) {
+                req_body.stuff_id = this.focus_scheme_stuff.id;
+            }
+            const req = this.make_context_req(req_body, '/sale_management/contract_set_discount_scheme', this.show_scope_switch, this.self_info && this.self_info.company_is_group === true, this.stat_context_company_id);
             await this.$send_req('/sale_management/contract_set_discount_scheme', req);
             this.show_contract_scheme_picker = false;
             uni.startPullDownRefresh();

--- a/mt_pc/src/components/ContractShowTable.vue
+++ b/mt_pc/src/components/ContractShowTable.vue
@@ -72,10 +72,24 @@
                             </div>
                         </template>
                 </el-table-column>
-                <el-table-column v-if="can_manage_discount" label="优惠策略" min-width="180">
+                <el-table-column v-if="can_manage_discount" label="优惠策略" min-width="220">
                     <template slot-scope="scope">
-                        <div>
-                            方案: {{ scope.row.discount_scheme ? scope.row.discount_scheme.name : '无' }}
+                        <div v-if="scope.row.contract_stuff_schemes && scope.row.contract_stuff_schemes.length > 0" class="contract-scheme-list">
+                            <el-tag
+                                v-for="scheme_row in scope.row.contract_stuff_schemes"
+                                :key="scheme_row.id || (scheme_row.stuffId + '-' + scheme_row.discountSchemeId)"
+                                size="mini"
+                                type="primary"
+                                class="contract-scheme-tag"
+                            >
+                                {{ format_scheme_tag_text(scheme_row) }}
+                            </el-tag>
+                        </div>
+                        <div v-else-if="scope.row.discount_scheme">
+                            方案: {{ scope.row.discount_scheme.name }}
+                        </div>
+                        <div v-else>
+                            方案: 无
                         </div>
                         <div v-if="scope.row.contract_stuff_prices && scope.row.contract_stuff_prices.length > 0">
                             <div>物料特价:</div>
@@ -214,17 +228,32 @@
             </el-table-column>
         </el-table>
     </el-dialog>
-    <el-dialog title="设置合同优惠方案" :visible.sync="show_contract_scheme_dialog" width="30%">
+    <el-dialog title="设置合同优惠方案" :visible.sync="show_contract_scheme_dialog" width="36%">
         <el-alert type="info" :closable="false" show-icon style="margin-bottom: 12px;">
             <template slot="title">单价计算优先级</template>
             <div style="font-size: 12px; line-height: 1.6;">
                 若该合同同时设置了"合同物料单价（一客一价）"，则<b>一客一价优先</b>，本方案不会生效；<br />
-                仅当未设置一客一价时，下单单价 = <b>物料基价 + 方案 delta</b>。
+                仅当未设置一客一价时，下单单价 = <b>物料基价 + 方案 delta</b>；<br />
+                计算优惠时<b>优先匹配合同-物料</b>专属方案，未设置时再使用合同默认方案。
             </div>
         </el-alert>
-        <el-select v-model="selected_scheme_id" clearable placeholder="请选择优惠方案" style="width: 100%;">
-            <el-option v-for="item in discount_schemes" :key="item.id" :label="`${item.name}（${item.delta_price}）`" :value="item.id"></el-option>
-        </el-select>
+        <el-form label-width="80px">
+            <el-form-item label="优惠物料">
+                <el-select v-model="scheme_selected_stuff_id" clearable placeholder="全部关联物料（默认）" style="width: 100%;" @change="sync_scheme_for_selected_stuff">
+                    <el-option
+                        v-for="item in contract_scheme_stuff_options"
+                        :key="item.id"
+                        :label="item.display_name"
+                        :value="item.id"
+                    ></el-option>
+                </el-select>
+            </el-form-item>
+            <el-form-item label="优惠方案">
+                <el-select v-model="selected_scheme_id" clearable placeholder="请选择优惠方案" style="width: 100%;">
+                    <el-option v-for="item in discount_schemes" :key="item.id" :label="`${item.name}（${item.delta_price}）`" :value="item.id"></el-option>
+                </el-select>
+            </el-form-item>
+        </el-form>
         <span slot="footer">
             <el-button @click="show_contract_scheme_dialog = false">取 消</el-button>
             <el-button type="primary" @click="save_contract_scheme">确 定</el-button>
@@ -306,6 +335,8 @@ export default {
             },
             show_contract_scheme_dialog: false,
             selected_scheme_id: null,
+            scheme_selected_stuff_id: null,
+            contract_scheme_stuff_options: [],
             show_stuff_price_dialog: false,
             stuff_price_rows: [],
         }
@@ -435,15 +466,43 @@ export default {
         },
         prepare_contract_scheme: async function (contract) {
             this.focus_contract = contract;
-            this.selected_scheme_id = contract.discountSchemeId || null;
+            this.contract_scheme_stuff_options = this.format_linked_stuff_list(contract.stuff || []);
+            this.scheme_selected_stuff_id = null;
             await this.load_discount_schemes();
+            this.sync_scheme_for_selected_stuff();
             this.show_contract_scheme_dialog = true;
         },
+        sync_scheme_for_selected_stuff: function () {
+            const rows = (this.focus_contract && this.focus_contract.contract_stuff_schemes) || [];
+            if (this.scheme_selected_stuff_id) {
+                const found = rows.find((row) => row.stuffId === this.scheme_selected_stuff_id);
+                this.selected_scheme_id = found ? found.discountSchemeId : null;
+                return;
+            }
+            if (rows.length > 0) {
+                const firstSchemeId = rows[0].discountSchemeId;
+                const allSame = rows.every((row) => row.discountSchemeId === firstSchemeId);
+                this.selected_scheme_id = allSame ? firstSchemeId : null;
+                return;
+            }
+            this.selected_scheme_id = (this.focus_contract && this.focus_contract.discountSchemeId) || null;
+        },
+        format_scheme_tag_text: function (scheme_row) {
+            const stuff_name = scheme_row.stuff && scheme_row.stuff.name ? scheme_row.stuff.name : `物料#${scheme_row.stuffId}`;
+            const scheme_name = scheme_row.discount_scheme && scheme_row.discount_scheme.name
+                ? scheme_row.discount_scheme.name
+                : '无';
+            return `${stuff_name}: ${scheme_name}`;
+        },
         save_contract_scheme: async function () {
-            await this.$send_req('/sale_management/contract_set_discount_scheme', this.make_context_req({
+            const req = {
                 contract_id: this.focus_contract.id,
                 scheme_id: this.selected_scheme_id || null,
-            }));
+            };
+            if (this.scheme_selected_stuff_id) {
+                req.stuff_id = this.scheme_selected_stuff_id;
+            }
+            await this.$send_req('/sale_management/contract_set_discount_scheme', this.make_context_req(req));
             this.show_contract_scheme_dialog = false;
             this.$message.success('设置成功');
             this.$refs.contracts.refresh(this.$refs.contracts.cur_page || 1);
@@ -722,6 +781,19 @@ export default {
 }
 
 .contract-stuff-tag {
+    white-space: normal;
+    height: auto;
+    line-height: 1.5;
+    max-width: 100%;
+}
+
+.contract-scheme-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+}
+
+.contract-scheme-tag {
     white-space: normal;
     height: auto;
     line-height: 1.5;


### PR DESCRIPTION
1. 增加基于合同-物料二元组的优惠方案应用
2. 
<img width="767" height="791" alt="image" src="https://github.com/user-attachments/assets/a44cee91-2e2b-479b-887c-c9a69104d915" />
<img width="698" height="424" alt="image" src="https://github.com/user-attachments/assets/c40bf1d8-a32e-4be3-b577-c26f850b9041" />
