### PR TITLE
ZYZL-744-采购结算保留结算周期配置键值对

### DIFF
--- a/api/db_opt.js
+++ b/api/db_opt.js
@@ -463,6 +463,7 @@ let db_opt = {
             id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
             buy_settle_time: { type: DataTypes.STRING, defaultValue: '00:00:00' },
             buy_settle_cycle: { type: DataTypes.INTEGER, defaultValue: 5 },
+            buy_stuff_prices: { type: DataTypes.TEXT, defaultValue: '[]' },
             buy_last_settle_time: { type: DataTypes.STRING },
             sale_settle_time: { type: DataTypes.STRING, defaultValue: '00:00:00' },
             sale_settle_cycle: { type: DataTypes.INTEGER, defaultValue: 5 },
@@ -482,6 +483,7 @@ let db_opt = {
             success: { type: DataTypes.BOOLEAN, defaultValue: false },
             execute_result: { type: DataTypes.STRING },
             operator: { type: DataTypes.STRING },
+            unit_price: { type: DataTypes.DECIMAL(12, 2), defaultValue: 0, get: getDecimalValue('unit_price') },
         },
         delegate: {
             id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },

--- a/api/lib/t_plus_lib.js
+++ b/api/lib/t_plus_lib.js
@@ -21,9 +21,9 @@ function map_plan_export_row(plan, company) {
     const plain = plan.toJSON ? plan.toJSON() : plan;
     const push_log = plain.tplus_push_log || {};
     const unit_price = (push_log.unit_price !== undefined && push_log.unit_price !== null)
-        ? (parseFloat(push_log.unit_price) || 0)
-        : (parseFloat(plain.unit_price) || 0);
-    const count = parseFloat(plain.count) || 0;
+        ? (Number.parseFloat(push_log.unit_price) || 0)
+        : (Number.parseFloat(plain.unit_price) || 0);
+    const count = Number.parseFloat(plain.count) || 0;
     return {
         plan_date: format_plan_datetime(plain),
         plate: plain.main_vehicle ? plain.main_vehicle.plate : '',
@@ -73,7 +73,7 @@ async function private_req2tplus(method, url, params, body, company) {
         }
     });
     let resp;
-    console.log(`call ${url + '?idMarketingOrgan=' + company.tplus_market_oid}\nreq:${JSON.stringify(body)}`);
+    console.log(`call ${method} ${url}?idMarketingOrgan=${company.tplus_market_oid}`);
     try {
         resp = await axios_instance({
             method: method,
@@ -148,7 +148,7 @@ function get_buy_settle_price(stuff_prices, stuff_id, fallback_price) {
     if (price_map.has(id)) {
         return price_map.get(id);
     }
-    return parseFloat(fallback_price) || 0;
+    return Number.parseFloat(fallback_price) || 0;
 }
 
 async function get_partner_code(sale_company, buy_company) {
@@ -542,7 +542,7 @@ module.exports = {
             const execute_result = plan.execute_result || '';
             const settle_unit_price = is_buy
                 ? get_buy_settle_price(buy_prices, plan.stuffId, plan.unit_price)
-                : (parseFloat(plan.unit_price) || 0);
+                : (Number.parseFloat(plan.unit_price) || 0);
             await plan.setTplus_settle_record(record);
 
             let push_log = await plan.getTplus_push_log();

--- a/api/lib/t_plus_lib.js
+++ b/api/lib/t_plus_lib.js
@@ -20,7 +20,9 @@ function format_plan_datetime(plan) {
 function map_plan_export_row(plan, company) {
     const plain = plan.toJSON ? plan.toJSON() : plan;
     const push_log = plain.tplus_push_log || {};
-    const unit_price = parseFloat(plain.unit_price) || 0;
+    const unit_price = (push_log.unit_price !== undefined && push_log.unit_price !== null)
+        ? (parseFloat(push_log.unit_price) || 0)
+        : (parseFloat(plain.unit_price) || 0);
     const count = parseFloat(plain.count) || 0;
     return {
         plan_date: format_plan_datetime(plain),
@@ -97,6 +99,58 @@ async function private_req2tplus(method, url, params, body, company) {
 
     return resp.data;
 }
+function parse_buy_stuff_prices(raw) {
+    if (Array.isArray(raw)) {
+        return raw.map((item) => ({
+            stuff_id: Number(item.stuff_id),
+            price: Number(Number(item.price).toFixed(2)),
+        })).filter((item) => item.stuff_id > 0 && !Number.isNaN(item.price));
+    }
+    if (!raw || typeof raw !== 'string') {
+        return [];
+    }
+    try {
+        return parse_buy_stuff_prices(JSON.parse(raw));
+    } catch (e) {
+        return [];
+    }
+}
+
+function stringify_buy_stuff_prices(prices) {
+    return JSON.stringify(parse_buy_stuff_prices(prices));
+}
+
+function apply_buy_stuff_prices(plans, stuff_prices) {
+    const price_map = new Map();
+    parse_buy_stuff_prices(stuff_prices).forEach((item) => {
+        price_map.set(item.stuff_id, item.price);
+    });
+    plans.forEach((plan) => {
+        const stuff_id = Number(plan.stuffId);
+        if (price_map.has(stuff_id)) {
+            const price = price_map.get(stuff_id);
+            if (typeof plan.setDataValue === 'function') {
+                plan.setDataValue('unit_price', price);
+            } else {
+                plan.unit_price = price;
+            }
+        }
+    });
+    return plans;
+}
+
+function get_buy_settle_price(stuff_prices, stuff_id, fallback_price) {
+    const price_map = new Map();
+    parse_buy_stuff_prices(stuff_prices).forEach((item) => {
+        price_map.set(item.stuff_id, item.price);
+    });
+    const id = Number(stuff_id);
+    if (price_map.has(id)) {
+        return price_map.get(id);
+    }
+    return parseFloat(fallback_price) || 0;
+}
+
 async function get_partner_code(sale_company, buy_company) {
     let ret = null;
     let resp = await private_req2tplus(
@@ -380,55 +434,75 @@ module.exports = {
         }
         return plans;
     },
+    parse_buy_stuff_prices,
+    stringify_buy_stuff_prices,
     get_or_create_config: async function (company) {
         let config = await company.getTplus_config();
         if (!config) {
             config = await company.createTplus_config({
                 buy_settle_time: '00:00:00',
                 buy_settle_cycle: 5,
+                buy_stuff_prices: '[]',
                 sale_settle_time: '00:00:00',
                 sale_settle_cycle: 5,
             });
         }
         return config;
     },
-    filter_unsettled_plans: async function (company, is_buy, cycle_days) {
+    filter_unsettled_plans: async function (company, is_buy, options) {
         const sq = db_opt.get_sq();
-        const stuff = await company.getStuff({ paranoid: false });
-        if (!stuff || stuff.length === 0) {
-            return [];
+        const opts = options || {};
+        let stuff_ids = Array.isArray(opts.stuff_ids) ? opts.stuff_ids.filter((id) => id > 0) : [];
+        if (stuff_ids.length === 0) {
+            const stuff = await company.getStuff({ paranoid: false });
+            if (!stuff || stuff.length === 0) {
+                return [];
+            }
+            // 未指定物料时，仅取已配置 stuff_code 的物料（与 main 推送逻辑一致）
+            stuff_ids = stuff.filter((s) => s.stuff_code).map((s) => s.id);
+            if (stuff_ids.length === 0) {
+                return [];
+            }
         }
-        const stuff_or = stuff.filter(s => s.stuff_code).map((s) => ({ stuffId: s.id }));
-        const start_date = moment().subtract(cycle_days || 5, 'days').format('YYYY-MM-DD');
-        const where_condition = {
-            [db_opt.Op.and]: [
-                {
-                    status: 3,
-                    manual_close: false,
-                    is_buy: !!is_buy,
-                    count: {
-                        [db_opt.Op.ne]: 0,
-                    },
-                    plan_time: {
-                        [db_opt.Op.gte]: start_date,
-                    },
+        const and_conditions = [
+            {
+                status: 3,
+                manual_close: false,
+                is_buy: !!is_buy,
+                count: {
+                    [db_opt.Op.ne]: 0,
                 },
-                {
-                    [db_opt.Op.or]: stuff_or,
-                },
-                // 推送成功过的计划不再推；无日志或失败可推
-                sq.literal(`(select count(*) from tplus_push_log where planId = plan.id AND deletedAt is Null AND success = 1) = 0`),
-            ],
+            },
+            {
+                [db_opt.Op.or]: stuff_ids.map((id) => ({ stuffId: id })),
+            },
+            // 推送成功过的计划不再推；无日志或失败可推
+            sq.literal(`(select count(*) from tplus_push_log where planId = plan.id AND deletedAt is Null AND success = 1) = 0`),
+        ];
+        const start_date = moment().subtract(opts.cycle_days || 5, 'days').format('YYYY-MM-DD');
+        and_conditions[0].plan_time = {
+            [db_opt.Op.gte]: start_date,
         };
         return await sq.models.plan.findAll({
-            where: where_condition,
+            where: {
+                [db_opt.Op.and]: and_conditions,
+            },
             include: util_lib.plan_detail_include(),
         });
     },
     do_settle: async function (company, is_buy, operator) {
         const config = await this.get_or_create_config(company);
-        const cycle = is_buy ? (config.buy_settle_cycle || 5) : (config.sale_settle_cycle || 5);
-        let plans = await this.filter_unsettled_plans(company, is_buy, cycle);
+        const buy_prices = parse_buy_stuff_prices(config.buy_stuff_prices);
+        const filter_opts = is_buy
+            ? {
+                stuff_ids: buy_prices.map((item) => item.stuff_id),
+                cycle_days: config.buy_settle_cycle || 5,
+            }
+            : { cycle_days: config.sale_settle_cycle || 5 };
+        let plans = await this.filter_unsettled_plans(company, is_buy, filter_opts);
+        if (is_buy) {
+            plans = apply_buy_stuff_prices(plans, buy_prices);
+        }
         const settle_type = is_buy ? 'buy' : 'sale';
         const settle_time = moment().format('YYYY-MM-DD HH:mm:ss');
         const op = operator || '系统';
@@ -466,6 +540,9 @@ module.exports = {
             const plan = plans[i];
             const success = !!plan.tplus_success;
             const execute_result = plan.execute_result || '';
+            const settle_unit_price = is_buy
+                ? get_buy_settle_price(buy_prices, plan.stuffId, plan.unit_price)
+                : (parseFloat(plan.unit_price) || 0);
             await plan.setTplus_settle_record(record);
 
             let push_log = await plan.getTplus_push_log();
@@ -474,6 +551,7 @@ module.exports = {
                 push_log.success = success;
                 push_log.execute_result = execute_result;
                 push_log.operator = op;
+                push_log.unit_price = settle_unit_price;
                 await push_log.save();
             } else {
                 await plan.createTplus_push_log({
@@ -481,6 +559,7 @@ module.exports = {
                     success,
                     execute_result,
                     operator: op,
+                    unit_price: settle_unit_price,
                 });
             }
         }
@@ -528,9 +607,7 @@ module.exports = {
                 continue;
             }
             try {
-                if (this.should_auto_settle(config.buy_last_settle_time, config.buy_settle_time, config.buy_settle_cycle)) {
-                    await this.do_settle(company, true, '定时任务');
-                }
+                // 采购仅支持手动结算，不走定时任务
                 if (this.should_auto_settle(config.sale_last_settle_time, config.sale_settle_time, config.sale_settle_cycle)) {
                     await this.do_settle(company, false, '定时任务');
                 }

--- a/api/module/tplus_module.js
+++ b/api/module/tplus_module.js
@@ -13,8 +13,13 @@ module.exports = {
             is_get_api: false,
             params: {},
             result: {
-                buy_settle_time: { type: String, mean: '采购结算时间点', example: '03:56:12' },
                 buy_settle_cycle: { type: Number, mean: '采购结算周期(天)', example: 5 },
+                buy_stuff_prices: {
+                    type: Array, mean: '采购结算物料价格(结算时覆盖单价)', explain: {
+                        stuff_id: { type: Number, mean: '物料ID', example: 1 },
+                        price: { type: Number, mean: '结算单价', example: 100.5 },
+                    },
+                },
                 buy_last_settle_time: { type: String, mean: '采购上次结算时间', example: '2024-09-08 12:31:34' },
                 sale_settle_time: { type: String, mean: '销售结算时间点', example: '03:56:12' },
                 sale_settle_cycle: { type: Number, mean: '销售结算周期(天)', example: 5 },
@@ -22,17 +27,31 @@ module.exports = {
             },
             func: async function (body, token) {
                 const company = await rbac_lib.get_company_by_token(token);
-                return await t_plus_lib.get_or_create_config(company);
+                const config = await t_plus_lib.get_or_create_config(company);
+                const plain = config.toJSON ? config.toJSON() : config;
+                return {
+                    buy_settle_cycle: plain.buy_settle_cycle,
+                    buy_stuff_prices: t_plus_lib.parse_buy_stuff_prices(plain.buy_stuff_prices),
+                    buy_last_settle_time: plain.buy_last_settle_time,
+                    sale_settle_time: plain.sale_settle_time,
+                    sale_settle_cycle: plain.sale_settle_cycle,
+                    sale_last_settle_time: plain.sale_last_settle_time,
+                };
             },
         },
         config_set: {
             name: '设置Tplus配置',
-            description: '设置采购/销售结算时间点与周期',
+            description: '设置采购周期与物料价格、销售结算时间点与周期',
             is_write: true,
             is_get_api: false,
             params: {
-                buy_settle_time: { type: String, have_to: false, mean: '采购结算时间点', example: '03:56:12' },
                 buy_settle_cycle: { type: Number, have_to: false, mean: '采购结算周期(天)', example: 5 },
+                buy_stuff_prices: {
+                    type: Array, have_to: false, mean: '采购结算物料价格(结算时覆盖单价)', explain: {
+                        stuff_id: { type: Number, have_to: true, mean: '物料ID', example: 1 },
+                        price: { type: Number, have_to: true, mean: '结算单价', example: 100.5 },
+                    },
+                },
                 sale_settle_time: { type: String, have_to: false, mean: '销售结算时间点', example: '03:56:12' },
                 sale_settle_cycle: { type: Number, have_to: false, mean: '销售结算周期(天)', example: 5 },
             },
@@ -42,11 +61,11 @@ module.exports = {
             func: async function (body, token) {
                 const company = await rbac_lib.get_company_by_token(token);
                 const config = await t_plus_lib.get_or_create_config(company);
-                if (body.buy_settle_time !== undefined) {
-                    config.buy_settle_time = body.buy_settle_time;
-                }
                 if (body.buy_settle_cycle !== undefined) {
                     config.buy_settle_cycle = body.buy_settle_cycle;
+                }
+                if (body.buy_stuff_prices !== undefined) {
+                    config.buy_stuff_prices = t_plus_lib.stringify_buy_stuff_prices(body.buy_stuff_prices);
                 }
                 if (body.sale_settle_time !== undefined) {
                     config.sale_settle_time = body.sale_settle_time;

--- a/mt_pc/src/views/tplus/Tplus.vue
+++ b/mt_pc/src/views/tplus/Tplus.vue
@@ -1,113 +1,132 @@
 <template>
-<div class="tplus-page">
-    <div class="page-header card">
-        <div class="header-left">
-            <img src="@/assets/tpluslogo.png" class="tplus-logo" alt="Tplus">
-            <div>
+    <div class="tplus-page">
+        <div class="page-header card">
+            <div class="header-left">
+                <img src="@/assets/tpluslogo.png" class="tplus-logo" alt="Tplus">
                 <div class="panel-title">Tplus 对接系统</div>
             </div>
         </div>
-    </div>
 
-    <div class="config-area">
-        <div class="config-block card">
-            <div class="panel-header">
-                <span class="panel-title">采购结算</span>
-            </div>
-            <div class="config-grid">
-                <div class="config-row">
-                    <span class="config-label">结算时间点</span>
-                    <el-time-picker
-                        v-model="buy_settle_time_value"
-                        value-format="HH:mm:ss"
-                        placeholder="选择时间"
-                        :clearable="false"
-                        class="config-control"
-                        @change="save_config"
-                    ></el-time-picker>
-                </div>
-                <div class="config-row">
-                    <span class="config-label">结算周期</span>
-                    <div class="cycle-wrap">
-                        <el-input-number v-model="config.buy_settle_cycle" :min="1" :max="365" @change="save_config"></el-input-number>
-                        <span class="unit-text">天</span>
+        <div class="main-card card">
+            <el-tabs v-model="active_tab" @tab-click="on_tab_click">
+                <el-tab-pane label="结算" name="settle">
+                    <div class="config-area">
+                        <div class="config-block">
+                            <div class="panel-header">
+                                <span class="section-title">采购结算</span>
+                                <el-button type="primary" class="action-btn" :disabled="!can_buy_settle"
+                                    :loading="buy_settling" @click="direct_settle(true)">直接结算</el-button>
+                            </div>
+                            <div class="buy-body">
+                                <div class="buy-top">
+                                    <span class="field-label">结算周期</span>
+                                    <div class="cycle-wrap">
+                                        <el-input-number v-model="config.buy_settle_cycle" :min="1" :max="365"
+                                            @change="save_config"></el-input-number>
+                                        <span class="unit-text">天</span>
+                                    </div>
+                                </div>
+                                <div class="buy-prices">
+                                    <div class="field-bar">
+                                        <span class="field-label">物料价格</span>
+                                        <el-button type="text" icon="el-icon-plus"
+                                            @click="add_buy_stuff_price">添加</el-button>
+                                    </div>
+                                    <el-table :data="buy_stuff_prices" size="small" border class="stuff-table"
+                                        empty-text="暂无物料，点击添加">
+                                        <el-table-column label="物料" min-width="160">
+                                            <template slot-scope="scope">
+                                                <el-select :key="'buy-stuff-' + scope.$index + '-' + selected_stuff_key"
+                                                    v-model="scope.row.stuff_id" filterable clearable placeholder="选择物料"
+                                                    size="small" style="width: 100%" @change="save_config">
+                                                    <el-option v-for="item in get_stuff_options_for_row(scope.$index)"
+                                                        :key="item.id" :label="item.name + ' (#' + item.id + ')'"
+                                                        :value="item.id"></el-option>
+                                                </el-select>
+                                            </template>
+                                        </el-table-column>
+                                        <el-table-column label="价格" width="150" align="center">
+                                            <template slot-scope="scope">
+                                                <el-input-number v-model="scope.row.price" :min="0" :precision="2"
+                                                    size="small" controls-position="right" class="price-input"
+                                                    @change="save_config"></el-input-number>
+                                            </template>
+                                        </el-table-column>
+                                        <el-table-column label="操作" width="64" align="center">
+                                            <template slot-scope="scope">
+                                                <el-button type="text" icon="el-icon-delete" class="remove-btn"
+                                                    @click="remove_buy_stuff_price(scope.$index)"></el-button>
+                                            </template>
+                                        </el-table-column>
+                                    </el-table>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="config-block">
+                            <div class="panel-header">
+                                <span class="section-title">销售结算</span>
+                                <el-button type="primary" class="action-btn" :loading="sale_settling"
+                                    @click="direct_settle(false)">直接结算</el-button>
+                            </div>
+                            <div class="sale-body">
+                                <div class="sale-field">
+                                    <div class="field-label">结算时间点</div>
+                                    <el-time-picker v-model="sale_settle_time_value" value-format="HH:mm:ss"
+                                        placeholder="选择时间" :clearable="false" class="time-picker"
+                                        @change="save_config"></el-time-picker>
+                                </div>
+                                <div class="sale-field">
+                                    <div class="field-label">结算周期</div>
+                                    <div class="cycle-wrap">
+                                        <el-input-number v-model="config.sale_settle_cycle" :min="1" :max="365"
+                                            @change="save_config"></el-input-number>
+                                        <span class="unit-text">天</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                     </div>
-                </div>
-            </div>
-            <el-button class="action-btn" type="primary" :loading="buy_settling" @click="direct_settle(true)">直接结算</el-button>
-        </div>
+                </el-tab-pane>
 
-        <div class="config-block card">
-            <div class="panel-header">
-                <span class="panel-title">销售结算</span>
-            </div>
-            <div class="config-grid">
-                <div class="config-row">
-                    <span class="config-label">结算时间点</span>
-                    <el-time-picker
-                        v-model="sale_settle_time_value"
-                        value-format="HH:mm:ss"
-                        placeholder="选择时间"
-                        :clearable="false"
-                        class="config-control"
-                        @change="save_config"
-                    ></el-time-picker>
-                </div>
-                <div class="config-row">
-                    <span class="config-label">结算周期</span>
-                    <div class="cycle-wrap">
-                        <el-input-number v-model="config.sale_settle_cycle" :min="1" :max="365" @change="save_config"></el-input-number>
-                        <span class="unit-text">天</span>
+                <el-tab-pane label="结算记录" name="records">
+                    <div class="record-box">
+                        <div class="record-toolbar">
+                            <el-button class="export-btn" type="primary" icon="el-icon-refresh"
+                                @click="refresh_records">刷新</el-button>
+                        </div>
+                        <page-content v-if="records_ready" ref="records" body_key="records" enable
+                            req_url="/tplus/settle_records_get" :req_body="{}">
+                            <template v-slot:default="slotProps">
+                                <div class="record-table-wrap">
+                                    <el-table :data="slotProps.content" style="width: 100%" height="100%"
+                                        class="record-table">
+                                        <el-table-column prop="settle_time" label="结算时间"
+                                            min-width="180"></el-table-column>
+                                        <el-table-column prop="settle_type" label="类型" min-width="100">
+                                            <template slot-scope="scope">
+                                                {{ scope.row.settle_type === 'buy' ? '采购' : '销售' }}
+                                            </template>
+                                        </el-table-column>
+                                        <el-table-column prop="status" label="结算状态" min-width="140"></el-table-column>
+                                        <el-table-column prop="plate_summary" label="车号"
+                                            min-width="140"></el-table-column>
+                                        <el-table-column prop="operator" label="操作人" min-width="120"></el-table-column>
+                                        <el-table-column label="操作" width="120" fixed="right">
+                                            <template slot-scope="scope">
+                                                <el-button type="text" :loading="exporting_id === scope.row.id"
+                                                    @click="export_record_detail(scope.row)">导出详情</el-button>
+                                            </template>
+                                        </el-table-column>
+                                    </el-table>
+                                </div>
+                            </template>
+                        </page-content>
                     </div>
-                </div>
-            </div>
-            <el-button class="action-btn" type="primary" :loading="sale_settling" @click="direct_settle(false)">直接结算</el-button>
+                </el-tab-pane>
+            </el-tabs>
         </div>
     </div>
-
-    <div class="record-box card">
-        <div class="panel-header">
-            <div class="record-title-row">
-                <span class="panel-title">结算记录</span>
-            </div>
-            <div class="header-actions">
-                <el-button class="export-btn" type="primary" icon="el-icon-refresh" @click="refresh_records">刷新</el-button>
-            </div>
-        </div>
-        <page-content
-            ref="records"
-            body_key="records"
-            enable
-            req_url="/tplus/settle_records_get"
-            :req_body="{}"
-        >
-            <template v-slot:default="slotProps">
-                <div class="record-table-wrap">
-                    <el-table :data="slotProps.content" style="width: 100%" height="100%" class="record-table">
-                        <el-table-column prop="settle_time" label="结算时间" min-width="180"></el-table-column>
-                        <el-table-column prop="settle_type" label="类型" min-width="100">
-                            <template slot-scope="scope">
-                                {{ scope.row.settle_type === 'buy' ? '采购' : '销售' }}
-                            </template>
-                        </el-table-column>
-                        <el-table-column prop="status" label="结算状态" min-width="140"></el-table-column>
-                        <el-table-column prop="plate_summary" label="车号" min-width="140"></el-table-column>
-                        <el-table-column prop="operator" label="操作人" min-width="120"></el-table-column>
-                        <el-table-column label="操作" width="120" fixed="right">
-                            <template slot-scope="scope">
-                                <el-button
-                                    type="text"
-                                    :loading="exporting_id === scope.row.id"
-                                    @click="export_record_detail(scope.row)"
-                                >导出详情</el-button>
-                            </template>
-                        </el-table-column>
-                    </el-table>
-                </div>
-            </template>
-        </page-content>
-    </div>
-</div>
 </template>
 
 <script>
@@ -119,36 +138,96 @@ export default {
     },
     data: function () {
         return {
+            active_tab: 'settle',
+            records_ready: false,
             config: {
-                buy_settle_time: '00:00:00',
                 buy_settle_cycle: 5,
                 sale_settle_time: '00:00:00',
                 sale_settle_cycle: 5,
             },
-            buy_settle_time_value: '00:00:00',
             sale_settle_time_value: '00:00:00',
+            buy_stuff_prices: [],
+            buy_stuff_options: [],
             buy_settling: false,
             sale_settling: false,
             saving: false,
             exporting_id: null,
         }
     },
+    computed: {
+        can_buy_settle: function () {
+            return this.get_valid_buy_stuff_prices().length > 0
+        },
+        selected_stuff_key: function () {
+            return this.buy_stuff_prices.map((row) => row.stuff_id || '').join(',')
+        },
+    },
     methods: {
+        on_tab_click: function (tab) {
+            if (tab.name === 'records') {
+                this.records_ready = true
+                this.$nextTick(() => {
+                    this.refresh_records()
+                })
+            }
+        },
         refresh_records: function () {
             if (this.$refs.records) {
                 this.$refs.records.refresh(1)
             }
         },
+        normalize_buy_stuff_prices: function (list) {
+            const rows = Array.isArray(list) ? list : []
+            return rows
+                .map((item) => ({
+                    stuff_id: item.stuff_id ? Number(item.stuff_id) : null,
+                    price: item.price === undefined || item.price === null || item.price === ''
+                        ? undefined
+                        : Number(item.price),
+                }))
+                .filter((item) => item.stuff_id)
+        },
+        get_valid_buy_stuff_prices: function () {
+            return this.normalize_buy_stuff_prices(this.buy_stuff_prices)
+                .filter((item) => item.price !== undefined && !Number.isNaN(item.price))
+        },
+        is_stuff_selected: function (stuff_id, current_index) {
+            return this.buy_stuff_prices.some((row, index) => {
+                return index !== current_index && Number(row.stuff_id) === Number(stuff_id)
+            })
+        },
+        get_stuff_options_for_row: function (current_index) {
+            return this.buy_stuff_options.filter((item) => {
+                return !this.is_stuff_selected(item.id, current_index)
+            })
+        },
+        add_buy_stuff_price: function () {
+            this.buy_stuff_prices.push({
+                stuff_id: null,
+                price: undefined,
+            })
+        },
+        remove_buy_stuff_price: async function (index) {
+            this.buy_stuff_prices.splice(index, 1)
+            await this.save_config()
+        },
+        init_stuff_options: async function () {
+            const resp = await this.$send_req('/stuff/get_all', {})
+            const stuff_list = (resp && resp.stuff) ? resp.stuff : []
+            this.buy_stuff_options = stuff_list.filter((item) => item.use_for_buy)
+            if (this.buy_stuff_options.length === 0) {
+                this.buy_stuff_options = stuff_list
+            }
+        },
         init_config: async function () {
             const resp = await this.$send_req('/tplus/config_get', {})
             this.config = {
-                buy_settle_time: resp.buy_settle_time || '00:00:00',
                 buy_settle_cycle: resp.buy_settle_cycle || 5,
                 sale_settle_time: resp.sale_settle_time || '00:00:00',
                 sale_settle_cycle: resp.sale_settle_cycle || 5,
             }
-            this.buy_settle_time_value = this.config.buy_settle_time
             this.sale_settle_time_value = this.config.sale_settle_time
+            this.buy_stuff_prices = this.normalize_buy_stuff_prices(resp.buy_stuff_prices)
         },
         save_config: async function () {
             if (this.saving) {
@@ -157,12 +236,11 @@ export default {
             this.saving = true
             try {
                 await this.$send_req('/tplus/config_set', {
-                    buy_settle_time: this.buy_settle_time_value || '00:00:00',
                     buy_settle_cycle: this.config.buy_settle_cycle,
+                    buy_stuff_prices: this.get_valid_buy_stuff_prices(),
                     sale_settle_time: this.sale_settle_time_value || '00:00:00',
                     sale_settle_cycle: this.config.sale_settle_cycle,
                 })
-                this.config.buy_settle_time = this.buy_settle_time_value
                 this.config.sale_settle_time = this.sale_settle_time_value
             } finally {
                 this.saving = false
@@ -178,7 +256,7 @@ export default {
                 await this.save_config()
                 const resp = await this.$send_req('/tplus/direct_settle', { is_buy: is_buy })
                 this.$message.success(resp.status || '结算完成')
-                this.refresh_records()
+                this.records_ready = true
             } finally {
                 if (is_buy) {
                     this.buy_settling = false
@@ -198,6 +276,7 @@ export default {
         },
     },
     mounted: async function () {
+        await this.init_stuff_options()
         await this.init_config()
     },
 }
@@ -238,57 +317,143 @@ export default {
     object-fit: contain;
 }
 
-.panel-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-}
-
 .panel-title {
     color: #1f2d3d;
     font-size: 20px;
     font-weight: 600;
 }
 
+.main-card {
+    flex: 1;
+    min-height: 0;
+    padding: 8px 18px 16px;
+    display: flex;
+    flex-direction: column;
+}
+
+.main-card /deep/ .el-tabs {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+.main-card /deep/ .el-tabs__header {
+    margin-bottom: 14px;
+}
+
+.main-card /deep/ .el-tabs__content {
+    flex: 1;
+    min-height: 0;
+    overflow: auto;
+}
+
+.main-card /deep/ .el-tab-pane {
+    height: 100%;
+}
+
+.panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.section-title {
+    color: #1f2d3d;
+    font-size: 18px;
+    font-weight: 600;
+}
 
 .config-area {
     display: flex;
+    align-items: flex-start;
     gap: 14px;
 }
 
 .config-block {
     flex: 1;
-    padding: 16px;
+    min-width: 0;
+    padding: 14px 16px;
+    border: 1px solid #ebf0f6;
+    border-radius: 10px;
+    background: #fafcff;
     display: flex;
     flex-direction: column;
     gap: 14px;
 }
 
-.config-grid {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(200px, 1fr));
-    gap: 10px;
-}
-
-.config-row {
-    border: 1px solid #ebf0f6;
-    border-radius: 10px;
-    padding: 10px 12px;
+.buy-body {
     display: flex;
-    justify-content: space-between;
-    align-items: center;
-    background: #fafcff;
-    gap: 10px;
+    flex-direction: column;
+    gap: 12px;
 }
 
-.config-label {
+.buy-top {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.buy-prices {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.field-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    min-height: 22px;
+}
+
+.field-label {
     color: #6f7d90;
     font-size: 14px;
+    line-height: 22px;
     white-space: nowrap;
 }
 
-.config-control {
+.time-picker {
     width: 150px;
+}
+
+.stuff-table {
+    width: 100%;
+}
+
+.stuff-table /deep/ th {
+    background: #f8fafc !important;
+    color: #6f7d90;
+    font-weight: 600;
+}
+
+.stuff-table /deep/ .cell {
+    padding-left: 8px;
+    padding-right: 8px;
+}
+
+.price-input {
+    width: 130px;
+}
+
+.sale-body {
+    display: flex;
+    gap: 20px;
+    align-items: flex-end;
+    flex-wrap: wrap;
+}
+
+.sale-field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    width: 180px;
+}
+
+.sale-field .time-picker {
+    width: 100%;
 }
 
 .cycle-wrap {
@@ -302,47 +467,39 @@ export default {
     font-size: 14px;
 }
 
+.remove-btn {
+    color: #f56c6c !important;
+    padding: 0;
+}
+
 .action-btn {
-    width: 132px;
-    font-size: 16px;
-    height: 42px;
-    border-radius: 10px;
-    align-self: flex-start;
+    width: 116px;
+    height: 36px;
+    font-size: 14px;
+    border-radius: 8px;
 }
 
 .export-btn {
     border-radius: 10px;
 }
 
-.header-actions {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    flex-shrink: 0;
-}
-
-.record-title-row {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    flex: 1;
-    min-width: 0;
-    margin-right: 12px;
-}
-
 .record-box {
-    flex: 1;
+    height: 100%;
     min-height: 0;
-    padding: 16px;
     display: flex;
     flex-direction: column;
     gap: 12px;
 }
 
+.record-toolbar {
+    display: flex;
+    justify-content: flex-end;
+}
+
 .record-table-wrap {
     flex: 1;
-    min-height: 280px;
-    height: calc(100vh - 420px);
+    min-height: 360px;
+    height: calc(100vh - 280px);
 }
 
 .record-table /deep/ th {
@@ -357,7 +514,7 @@ export default {
 
 .tplus-page /deep/ .el-input__inner,
 .tplus-page /deep/ .el-input-number .el-input__inner {
-    border-radius: 10px;
+    border-radius: 8px;
     border-color: #d8e0ec;
 }
 


### PR DESCRIPTION
1.采购保留结算周期+物料价格键值对，去掉结算时间点，仅支持手动结算
2.结算按配置物料筛单，用配置价覆盖推送单价；push_log单价从配置按物料ID取值
3.direct_settle只传is_buy，不再接收stuff_prices，不校验价格数组为空