### PR TITLE
ZYZL-761-出现错误的权限提示

### DIFF
--- a/mt_gui/src/pages/OrderList.vue
+++ b/mt_gui/src/pages/OrderList.vue
@@ -529,8 +529,12 @@ export default {
             }
         },
         refresh_approval_projects: async function () {
+            if (!this.$has_module('approval')) {
+                this.approval_projects = [];
+                return;
+            }
             try {
-                const ret = await this.$send_req('/approval/get_approval_projects', {});
+                const ret = await this.$send_req('/approval/get_approval_projects', {}, false, true);
                 this.approval_projects = ret.projects || [];
             } catch (err) {
                 console.log(err);

--- a/mt_gui/src/subPage1/OrderDetailPanel.vue
+++ b/mt_gui/src/subPage1/OrderDetailPanel.vue
@@ -862,8 +862,12 @@ export default {
             this.refresh_detail();
         },
         refresh_approval_projects: async function () {
+            if (!this.$has_module('approval')) {
+                this.approval_projects = [];
+                return;
+            }
             try {
-                const ret = await this.$send_req('/approval/get_approval_projects', {});
+                const ret = await this.$send_req('/approval/get_approval_projects', {}, false, true);
                 this.approval_projects = ret.projects || [];
             } catch (err) {
                 console.warn('refresh_approval_projects failed', err);


### PR DESCRIPTION
1.无 $has_module('approval') 时直接返回空配置，不请求新审批模块