### PR TITLE
ZYZL-772-订单的红字需要显示全

### DIFF
--- a/mt_gui/src/pages/OrderList.vue
+++ b/mt_gui/src/pages/OrderList.vue
@@ -1864,9 +1864,9 @@ export default {
     margin-top: 4rpx;
     font-size: 20rpx;
     color: #FF4D4F;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    line-height: 1.4;
+    word-break: break-all;
+    white-space: normal;
 }
 
 .picker-title {


### PR DESCRIPTION
1.红字显示全
<img width="476" height="190" alt="image" src="https://github.com/user-attachments/assets/81eee5bb-ba75-4012-9edc-b999082dbc93" />
